### PR TITLE
Sposta copertina, giornata e pubblicazione dal modello al codice

### DIFF
--- a/.github/workflows/gazzetta-cover.yml
+++ b/.github/workflows/gazzetta-cover.yml
@@ -10,7 +10,18 @@ on:
     branches: [main]
     paths:
       - 'public/articoli/md/**.md'
-  workflow_dispatch:   # avvio manuale dalla tab Actions (rigenera le immagini mancanti)
+  workflow_dispatch:   # avvio manuale dalla tab Actions (rigenera una copertina senza toccare l'articolo)
+    inputs:
+      slug:
+        description: "slug dell'articolo, es. gazzetta-g7"
+        required: false
+      seed:
+        description: "seed alternativo per una variante"
+        required: false
+      force:
+        description: "sovrascrivi la copertina esistente"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -36,7 +47,19 @@ jobs:
 
       - name: Genera copertine mancanti
         id: build
-        run: node scripts/gazzetta/build_cover_from_md.js --all
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          IMAGE_SEED: ${{ github.event.inputs.seed }}
+        run: |
+          ARGS="--all"
+          if [[ -n "${{ github.event.inputs.slug }}" ]]; then
+            ARGS="public/articoli/md/${{ github.event.inputs.slug }}.md"
+          fi
+          if [[ "${{ github.event.inputs.force }}" == "true" ]]; then
+            ARGS="$ARGS --force"
+          fi
+          node scripts/gazzetta/build_cover_from_md.js $ARGS
 
       - name: Commit immagini generate
         run: |

--- a/app/api/gazzetta/publish/route.ts
+++ b/app/api/gazzetta/publish/route.ts
@@ -1,0 +1,321 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+import matter from 'gray-matter';
+import { getSeason } from '@/lib/seasons';
+
+export const runtime = 'nodejs';
+
+const GITHUB_API = 'https://api.github.com';
+
+function ghHeaders(token: string) {
+    return {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'fantalaghee-publish',
+    };
+}
+
+/** Confronto a tempo costante tra il token ricevuto e il secret configurato. */
+function autenticato(request: NextRequest, secret: string): boolean {
+    const header = request.headers.get('authorization') || '';
+    const match = header.match(/^Bearer\s+(.+)$/);
+    const fornito = match ? match[1] : '';
+    const a = Buffer.from(fornito);
+    const b = Buffer.from(secret);
+    if (a.length !== b.length) return false;
+    return crypto.timingSafeEqual(a, b);
+}
+
+/** Valida a mano il payload, accumulando TUTTI gli errori trovati. */
+function valida(payload: any): string[] {
+    const errori: string[] = [];
+
+    if (typeof payload?.title !== 'string' || !payload.title.trim()) {
+        errori.push('title: mancante o vuoto');
+    }
+
+    if (typeof payload?.description !== 'string' || !payload.description.trim()) {
+        errori.push('description: mancante o vuoto');
+    } else if (payload.description.length > 200) {
+        errori.push(`description: troppo lunga (${payload.description.length} caratteri, massimo 200)`);
+    }
+
+    if (typeof payload?.body_md !== 'string' || !payload.body_md.trim()) {
+        errori.push('body_md: mancante o vuoto');
+    } else if (payload.body_md.trim().length < 500) {
+        errori.push(`body_md: troppo corto (${payload.body_md.trim().length} caratteri, minimo 500 - probabile generazione troncata)`);
+    }
+
+    if (typeof payload?.cover !== 'object' || payload.cover === null) {
+        errori.push('cover: mancante');
+    } else {
+        const c = payload.cover;
+        if (typeof c.titolo_principale !== 'string' || !c.titolo_principale.trim()) {
+            errori.push('cover.titolo_principale: mancante o vuoto');
+        } else if (c.titolo_principale.length > 60) {
+            errori.push(`cover.titolo_principale: troppo lungo (${c.titolo_principale.length} caratteri, massimo 60)`);
+        }
+
+        if (typeof c.sottotitolo !== 'string' || !c.sottotitolo.trim()) {
+            errori.push('cover.sottotitolo: mancante o vuoto');
+        } else if (c.sottotitolo.length > 200) {
+            errori.push(`cover.sottotitolo: troppo lungo (${c.sottotitolo.length} caratteri, massimo 200)`);
+        }
+
+        if (typeof c.image_prompt !== 'string' || !c.image_prompt.trim()) {
+            errori.push('cover.image_prompt: mancante o vuoto');
+        }
+
+        if ('box1' in c || 'box2' in c || 'box3' in c) {
+            errori.push('cover.box1/box2/box3: non vanno inclusi, li calcola il server dai dati reali di /api/verdetto');
+        }
+    }
+
+    if (payload?.box1 !== undefined || payload?.box2 !== undefined || payload?.box3 !== undefined) {
+        errori.push('box1/box2/box3: non vanno inclusi nel payload, li calcola il server dai dati reali di /api/verdetto');
+    }
+
+    if (payload?.giornata !== undefined && (typeof payload.giornata !== 'number' || !Number.isInteger(payload.giornata) || payload.giornata <= 0)) {
+        errori.push('giornata: se presente deve essere un numero intero positivo');
+    }
+
+    if (payload?.stagione !== undefined && typeof payload.stagione !== 'string') {
+        errori.push('stagione: se presente deve essere una stringa');
+    }
+
+    if (payload?.force !== undefined && typeof payload.force !== 'boolean') {
+        errori.push('force: se presente deve essere booleano');
+    }
+
+    return errori;
+}
+
+/** Scarta valori senza contenuto reale ('N/D', vuoto, NaN). */
+function pulisci(v: any): string | null {
+    if (v === undefined || v === null) return null;
+    const s = String(v).trim();
+    if (!s || s === 'N/D' || s.toLowerCase() === 'nan') return null;
+    return s;
+}
+
+function costruisciBox1(dati: any) {
+    const podio = Array.isArray(dati?.podio) ? dati.podio : [];
+    const rows: string[] = [];
+    podio.forEach((p: any) => {
+        const squadra = pulisci(p?.squadra);
+        const punteggio = pulisci(p?.punteggio);
+        if (squadra && punteggio) rows.push(`${rows.length + 1}. ${squadra}|${punteggio}`);
+    });
+    return { title: '🏆 TOP 5 DI GIORNATA', rows };
+}
+
+function costruisciBox2(dati: any) {
+    const classifica = Array.isArray(dati?.classifica) ? dati.classifica : [];
+    const rows: string[] = [];
+    classifica.slice(0, 5).forEach((c: any) => {
+        const squadra = pulisci(c?.squadra);
+        const punti = pulisci(c?.punti);
+        if (squadra && punti) rows.push(`${rows.length + 1}. ${squadra}|${punti}`);
+    });
+    return { title: '📊 CLASSIFICA GENERALE', rows };
+}
+
+function costruisciBox3(dati: any) {
+    const rows: string[] = [];
+
+    const campione = pulisci(dati?.campioneDiGiornata);
+    if (campione) rows.push(`Campione|${campione}`);
+
+    const recPunteggio = pulisci(dati?.recordAssoluto?.punteggio);
+    const recSquadra = pulisci(dati?.recordAssoluto?.squadra);
+    if (recPunteggio && recSquadra) rows.push(`Record|${recPunteggio} ${recSquadra}`);
+
+    const cucSquadra = pulisci(dati?.cucchiaioDiLegno?.squadra);
+    const cucPunteggio = pulisci(dati?.cucchiaioDiLegno?.punteggio);
+    if (cucSquadra && cucPunteggio) rows.push(`Cucchiaio|${cucSquadra} ${cucPunteggio}`);
+
+    return { title: '📌 I VERDETTI', rows };
+}
+
+/** GET contenuti da GitHub: restituisce lo sha se il file esiste già, null se non esiste. */
+async function trovaShaEsistente(owner: string, repo: string, repoPath: string, token: string): Promise<string | null> {
+    const res = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/contents/${repoPath}?ref=main`, {
+        headers: ghHeaders(token),
+        cache: 'no-store',
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`GitHub ha risposto ${res.status} nel controllo esistenza file: ${body.slice(0, 200)}`);
+    }
+    const json = await res.json();
+    return json?.sha || null;
+}
+
+/** PUT contenuti su GitHub: crea o sovrascrive (se sha è passato) il file su main. */
+async function committaFile(owner: string, repo: string, repoPath: string, content: string, message: string, token: string, sha: string | null): Promise<string> {
+    const body: Record<string, unknown> = {
+        message,
+        content: Buffer.from(content, 'utf8').toString('base64'),
+        branch: 'main',
+    };
+    if (sha) body.sha = sha;
+
+    const res = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/contents/${repoPath}`, {
+        method: 'PUT',
+        headers: { ...ghHeaders(token), 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+        const body_ = await res.text().catch(() => '');
+        throw new Error(`GitHub ha rifiutato il commit (${res.status}): ${body_.slice(0, 300)}`);
+    }
+    const json = await res.json();
+    return json?.commit?.sha || '';
+}
+
+export async function POST(request: NextRequest) {
+    const publishSecret = process.env.GAZZETTA_PUBLISH_SECRET;
+    if (!publishSecret) {
+        return NextResponse.json(
+            { ok: false, error: 'GAZZETTA_PUBLISH_SECRET non configurato sul server: impossibile pubblicare in sicurezza.' },
+            { status: 500 }
+        );
+    }
+    if (!autenticato(request, publishSecret)) {
+        return NextResponse.json({ ok: false, error: 'Autenticazione mancante o non valida.' }, { status: 401 });
+    }
+
+    let payload: any;
+    try {
+        payload = await request.json();
+    } catch {
+        return NextResponse.json({ ok: false, error: 'Corpo della richiesta non è JSON valido.' }, { status: 400 });
+    }
+
+    const errori = valida(payload);
+    if (errori.length > 0) {
+        return NextResponse.json(
+            { ok: false, error: 'Payload non valido: correggi i campi indicati e riprova.', dettagli: errori },
+            { status: 400 }
+        );
+    }
+
+    const ghToken = process.env.GAZZETTA_GH_TOKEN;
+    if (!ghToken) {
+        return NextResponse.json(
+            { ok: false, error: 'GAZZETTA_GH_TOKEN non configurato sul server: impossibile committare su GitHub.' },
+            { status: 500 }
+        );
+    }
+
+    const url = new URL(request.url);
+    const origin = url.origin;
+    const season = getSeason(typeof payload.stagione === 'string' ? payload.stagione : undefined);
+    const stagione = season.slug;
+    const force = payload.force === true;
+
+    // 1. Giornata: dal payload, oppure da /api/gazzetta/stato
+    let giornata: number;
+    if (typeof payload.giornata === 'number') {
+        giornata = payload.giornata;
+    } else {
+        const statoRes = await fetch(`${origin}/api/gazzetta/stato?stagione=${encodeURIComponent(stagione)}`, { cache: 'no-store' });
+        const stato = await statoRes.json();
+        if (stato.stato !== 'PRONTA' && !force) {
+            return NextResponse.json(
+                { ok: false, error: stato.motivo || 'La gazzetta non è pronta per essere pubblicata.' },
+                { status: 409 }
+            );
+        }
+        giornata = stato.giornata;
+    }
+
+    // 2. Slug e percorso
+    const slug = `gazzetta-g${giornata}`;
+    const repoPath = `public/articoli/md/${slug}.md`;
+    const owner = process.env.GITHUB_REPO_OWNER || 'dritall';
+    const repo = process.env.GITHUB_REPO_NAME || 'fantalaghee';
+
+    // 3. Idempotenza: il file esiste già su main?
+    let shaEsistente: string | null;
+    try {
+        shaEsistente = await trovaShaEsistente(owner, repo, repoPath, ghToken);
+    } catch (e: any) {
+        return NextResponse.json(
+            { ok: false, error: `Impossibile verificare se l'articolo esiste già su GitHub: ${e.message}` },
+            { status: 502 }
+        );
+    }
+    if (shaEsistente && !force) {
+        return NextResponse.json(
+            { ok: false, error: `L'articolo della giornata ${giornata} (${slug}) esiste già. Passa force:true per sovrascriverlo.` },
+            { status: 409 }
+        );
+    }
+
+    // 4. Dati reali per i tre box (mai dal payload)
+    let dati: any;
+    try {
+        const verdettoRes = await fetch(`${origin}/api/verdetto?stagione=${encodeURIComponent(stagione)}`, { cache: 'no-store' });
+        dati = await verdettoRes.json();
+        if (!verdettoRes.ok || dati?.error) {
+            throw new Error(dati?.details || dati?.error || `/api/verdetto ha risposto ${verdettoRes.status}`);
+        }
+    } catch (e: any) {
+        return NextResponse.json(
+            { ok: false, error: `Impossibile leggere i dati della giornata da /api/verdetto: ${e.message}. Niente è stato pubblicato.` },
+            { status: 502 }
+        );
+    }
+
+    const box1 = costruisciBox1(dati);
+    const box2 = costruisciBox2(dati);
+    const box3 = costruisciBox3(dati);
+
+    // 5. Composizione del file (frontmatter via gray-matter, mai YAML a mano)
+    const isoDate = new Date().toISOString().slice(0, 10);
+    const frontmatter = {
+        title: payload.title,
+        date: isoDate,
+        description: payload.description,
+        author: "L'Oracolo del Laghèe",
+        image: `/image/gazzetta/${slug}.png`,
+        stagione,
+        cover: {
+            giornata,
+            titolo_principale: payload.cover.titolo_principale,
+            sottotitolo: payload.cover.sottotitolo,
+            image_prompt: payload.cover.image_prompt,
+            box1,
+            box2,
+            box3,
+        },
+    };
+    const fileContent = matter.stringify(`${payload.body_md.trim()}\n`, frontmatter);
+
+    // 6. Commit su GitHub
+    let commitSha: string;
+    try {
+        commitSha = await committaFile(owner, repo, repoPath, fileContent, `Gazzetta: giornata ${giornata}`, ghToken, shaEsistente);
+    } catch (e: any) {
+        return NextResponse.json(
+            { ok: false, error: `Commit su GitHub fallito: ${e.message}. Riprova; se persiste controlla GAZZETTA_GH_TOKEN.` },
+            { status: 502 }
+        );
+    }
+
+    // 7. Risposta
+    return NextResponse.json(
+        {
+            ok: true,
+            slug,
+            giornata,
+            commit: commitSha,
+            liveUrl: `https://www.fantalaghee.live/gazzetta/${slug}`,
+            coverUrl: `https://www.fantalaghee.live/image/gazzetta/${slug}.png`,
+        },
+        { status: 201 }
+    );
+}

--- a/app/api/gazzetta/stato/route.ts
+++ b/app/api/gazzetta/stato/route.ts
@@ -1,0 +1,116 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { getSeason } from '@/lib/seasons';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const DUE_ORE_MS = 2 * 60 * 60 * 1000;
+
+type Stato = 'PRONTA' | 'FOGLIO_DA_RICALCOLARE' | 'GIA_PUBBLICATA' | 'NON_ANCORA';
+
+/**
+ * Giornata di Serie A più alta già chiusa: endDateUtc passato da più di 2 ore
+ * e matchdayStatus diverso da "Playing" (veto, non fonte primaria: la data lo è).
+ * Ritorna 0 se /api/football non risponde o non ha giornate — non deve mai far
+ * fallire /api/gazzetta/stato.
+ */
+async function leggiGiornataChiusaSerieA(origin: string, stagione: string): Promise<number> {
+    try {
+        const res = await fetch(
+            `${origin}/api/football?endpoint=matchdays&stagione=${encodeURIComponent(stagione)}`,
+            { cache: 'no-store' }
+        );
+        const json = await res.json();
+        if (!json?.ok || !Array.isArray(json.data) || json.data.length === 0) return 0;
+
+        const ora = Date.now();
+        const chiuse = json.data.filter((g: any) => {
+            const fine = new Date(g.endDateUtc).getTime();
+            if (!fine || Number.isNaN(fine)) return false;
+            if (ora - fine <= DUE_ORE_MS) return false;
+            return g.matchdayStatus !== 'Playing';
+        });
+
+        if (chiuse.length === 0) return 0;
+        return Math.max(...chiuse.map((g: any) => Number(g.round) || 0));
+    } catch (e) {
+        console.error('Errore lettura /api/football in /api/gazzetta/stato:', e);
+        return 0;
+    }
+}
+
+/** Numero giornata calcolato sul foglio Google, letto da /api/verdetto. */
+async function leggiGiornataFoglio(origin: string, stagione: string): Promise<number> {
+    try {
+        const res = await fetch(`${origin}/api/verdetto?stagione=${encodeURIComponent(stagione)}`, { cache: 'no-store' });
+        const json = await res.json();
+        return Number(json?.numeroGiornata) || 0;
+    } catch (e) {
+        console.error('Errore lettura /api/verdetto in /api/gazzetta/stato:', e);
+        return 0;
+    }
+}
+
+/** Giornata più alta già pubblicata, dai nomi file public/articoli/md/gazzetta-g{N}.md. */
+function leggiGiornataPubblicata(): number {
+    try {
+        const mdDir = path.join(process.cwd(), 'public', 'articoli', 'md');
+        const files = fs.readdirSync(mdDir);
+        let max = 0;
+        for (const f of files) {
+            const m = f.match(/^gazzetta-g(\d+)\.md$/);
+            if (m) max = Math.max(max, parseInt(m[1], 10));
+        }
+        return max;
+    } catch (e) {
+        console.error('Errore lettura public/articoli/md in /api/gazzetta/stato:', e);
+        return 0;
+    }
+}
+
+export async function GET(request: NextRequest) {
+    const url = new URL(request.url);
+    const season = getSeason(url.searchParams.get('stagione'));
+    const stagione = season.slug;
+    const origin = url.origin;
+
+    const [giornataChiusaSerieA, giornataFoglio] = await Promise.all([
+        leggiGiornataChiusaSerieA(origin, stagione),
+        leggiGiornataFoglio(origin, stagione),
+    ]);
+    const giornataPubblicata = leggiGiornataPubblicata();
+
+    let stato: Stato;
+    let giornata: number;
+    let motivo: string;
+
+    if (giornataChiusaSerieA === 0) {
+        stato = 'NON_ANCORA';
+        giornata = giornataFoglio;
+        motivo = `Nessuna giornata di Serie A risulta ancora chiusa (il foglio è fermo alla giornata ${giornataFoglio}): non c'è ancora niente da raccontare.`;
+    } else if (giornataFoglio < giornataChiusaSerieA) {
+        stato = 'FOGLIO_DA_RICALCOLARE';
+        giornata = giornataChiusaSerieA;
+        motivo = `La giornata ${giornataChiusaSerieA} di Serie A è chiusa, ma il foglio è ancora fermo alla giornata ${giornataFoglio}: va fatto ricalcolare.`;
+    } else if (giornataFoglio <= giornataPubblicata) {
+        stato = 'GIA_PUBBLICATA';
+        giornata = giornataFoglio;
+        motivo = `La giornata ${giornataFoglio} è già stata pubblicata (ultima gazzetta pubblicata: giornata ${giornataPubblicata}).`;
+    } else {
+        stato = 'PRONTA';
+        giornata = giornataFoglio;
+        motivo = `La giornata ${giornataFoglio} è chiusa, il foglio è aggiornato e la gazzetta non è ancora stata pubblicata.`;
+    }
+
+    return NextResponse.json({
+        stagione,
+        giornata,
+        pronta: stato === 'PRONTA',
+        stato,
+        motivo,
+        slugAtteso: `gazzetta-g${giornata}`,
+        dettaglio: { giornataChiusaSerieA, giornataFoglio, giornataPubblicata },
+    });
+}

--- a/docs/AUTOMAZIONE_GAZZETTA.md
+++ b/docs/AUTOMAZIONE_GAZZETTA.md
@@ -5,99 +5,106 @@
 > le sessioni di Claude Code non condividono memoria tra loro. Leggi prima questo file,
 > poi continua da qui.
 
-## ⚡ STATO AGGIORNATO (12 luglio 2026) — architettura definitiva, manca solo un token
+## ⚡ STATO AGGIORNATO (29 luglio 2026) — le tre responsabilità spostate dal modello al codice
 
-### L'architettura scelta (cambiata rispetto alla prima idea)
+### Il principio
 
-Il piano iniziale prevedeva un bot Telegram standalone scritto da noi (`scripts/gazzetta/bot.js`,
-sempre acceso, lettura HERMES_API_KEY su OpenRouter). **Quel bot esiste ancora nel repo ma non è
-più la via scelta**: l'utente ha già un agente proprio, "Hermes" (Nous), collegato a Telegram,
-GitHub e OpenRouter. Quindi Hermes stesso fa da orchestratore — non serve un bot separato sempre
-acceso. Il ruolo di ogni pezzo:
+Fino a questa iterazione, Hermes scriveva prosa, copiava numeri a mano, componeva YAML e
+faceva un commit git — tre mestieri che non sono i suoi, e nei quali sbagliava (in
+particolare: nessun token GitHub nel suo ambiente, quindi il commit finale non partiva
+mai). Il principio applicato qui: **il modello scrive solo prosa e un prompt d'immagine;
+ogni numero che finisce in copertina lo mette il codice, rileggendolo dalla fonte
+(`/api/verdetto`).** Hermes non ha più bisogno di GitHub, non genera immagini, non
+compila i box dati e non deve più sapere a memoria il numero di giornata.
 
-- **Hermes** (agente Telegram dell'utente): legge i dati, scrive l'articolo, scrive il prompt
-  dell'immagine, committa il `.md` su GitHub, manda la bozza e il messaggio WhatsApp finale.
-  **Segue `docs/HERMES_PLAYBOOK.md`** (letto dal branch `main` a ogni esecuzione).
-- **GitHub Action** (`.github/workflows/gazzetta-cover.yml`): quando arriva un commit con un
-  articolo che ha il blocco `cover:`, genera l'illustrazione hero (Pollinations.ai, gratis,
-  nessuna chiave) e compone la copertina finale PNG con Puppeteer, poi la committa.
-- **Vercel**: pubblica in automatico a ogni push su `main` (già configurato da prima, non
-  toccato da questo lavoro).
+### Chi fa cosa, oggi
 
-Verificato con ricerca: **Hermes 4 di Nous è un modello di solo testo**, non genera immagini
-nativamente — per questo la generazione dell'illustrazione è stata spostata dalla Action
-(Pollinations) invece che da Hermes via tool `image_generate` (che richiederebbe una `FAL_KEY`
-non disponibile nell'ambiente di Hermes).
+- **Hermes** (agente Telegram dell'utente): legge `/api/gazzetta/stato`, scrive
+  l'articolo e un `image_prompt` in inglese, manda la bozza su Telegram per l'OK
+  dell'utente, poi pubblica con **una singola `POST /api/gazzetta/publish`**.
+  **Segue `docs/HERMES_PLAYBOOK.md`** (riscritto: 5 passi invece di 8, zero YAML, zero
+  git). Nessun accesso GitHub necessario.
+- **`app/api/gazzetta/stato/route.ts`** (nuovo): incrocia tre fonti — calendario Serie A
+  (`/api/football?endpoint=matchdays`), foglio (`/api/verdetto`), filesystem
+  (`public/articoli/md/gazzetta-g{N}.md`) — e risponde con un solo verdetto:
+  `PRONTA` / `FOGLIO_DA_RICALCOLARE` / `GIA_PUBBLICATA` / `NON_ANCORA`, più un `motivo`
+  in italiano che Hermes può riportare così com'è all'utente. Elimina l'attesa "a occhio"
+  del vecchio playbook e la domanda "che giornata è" all'utente.
+- **`app/api/gazzetta/publish/route.ts`** (nuovo): riceve la bozza di Hermes (title,
+  description, body_md, cover con titolo/sottotitolo/image_prompt), valida tutto a mano,
+  rifiuta un payload che include `box1/2/3` (li ricalcola da solo da `/api/verdetto`),
+  compone il frontmatter con `gray-matter` (mai YAML a mano) e committa il `.md` su
+  `main` via GitHub Contents API, autenticato con un token server-side che Hermes non
+  vede mai. Protetto da `Authorization: Bearer {GAZZETTA_PUBLISH_SECRET}`. Idempotente:
+  un articolo già esistente per quella giornata risponde `409` a meno di `force:true`.
+- **`scripts/gazzetta/lib/imagegen.js`** (riscritto): catena di provider
+  `google` (Nano Banana 2 via Gemini, primario) → `openrouter` (Image API, scorta) →
+  `pollinations` (gratis, ultima rete). I primi due ricevono in ingresso due copertine
+  storiche della testata (`gazzetta-g30-sorpasso.webp`, `gazzetta-g28-triello-onda.webp`)
+  come riferimento di stile, per restare coerenti con le copertine disegnate a mano.
+  Firma di `generateHero()` invariata, così `build_cover_from_md.js` non ha dovuto
+  cambiare la chiamata.
+- **`scripts/gazzetta/build_cover_from_md.js`** (corretto): un `.md` con blocco `cover`
+  ma senza illustrazione generabile ora fa fallire lo script (`exit 1`), invece di
+  pubblicare in silenzio una copertina senza hero come succedeva prima. Un `.md` senza
+  blocco `cover` (i vecchi articoli scritti a mano) resta un salto legittimo, non un
+  errore.
+- **GitHub Action** (`.github/workflows/gazzetta-cover.yml`): genera l'hero e compone la
+  copertina finale con Puppeteer. Ora riceve `GEMINI_API_KEY`/`OPENROUTER_API_KEY` solo
+  sullo step di build, non fa mai passare verde un fallimento reale (nessun
+  `continue-on-error`), e accetta `slug`/`seed`/`force` da `workflow_dispatch` per
+  rigenerare una copertina senza toccare l'articolo.
+- **Vercel**: pubblica in automatico a ogni push su `main` (invariato).
 
 ### Il flusso completo, oggi
 
 ```
 Utente -> messaggio a Hermes su Telegram ("fai la gazzetta")
-       -> Hermes accende il calcolo sul Google Sheet (Apps Script Web App)
-       -> attende ~3 min
-       -> legge i dati da /api/verdetto (nessuna credenziale, CSV pubblico)
-       -> scrive l'articolo (voce Buffa/Ziliani/Pardo) + un "image_prompt"
+       -> Hermes: GET /api/gazzetta/stato
+          - GIA_PUBBLICATA / NON_ANCORA -> riporta il motivo, fine
+          - FOGLIO_DA_RICALCOLARE -> sveglia l'Apps Script, ripolla stato ogni 60s (max 5)
+          - PRONTA -> continua
+       -> GET /api/verdetto -> scrive l'articolo + image_prompt (inglese)
        -> manda la BOZZA testuale su Telegram
 Utente -> OK (o correzioni -> Hermes riscrive)
-       -> Hermes committa SOLO il file .md su GitHub (branch main), con:
-            - il testo dell'articolo
-            - cover.image_prompt (descrizione in inglese dell'illustrazione satirica)
-            - cover.box1/2/3 = DATI reali (Top 5 giornata, Classifica, Verdetti)
-GitHub Action -> genera l'hero da image_prompt (Pollinations) 
+       -> Hermes: POST /api/gazzetta/publish { title, description, body_md, cover }
+Server -> risolve la giornata, verifica idempotenza su GitHub, richiama /api/verdetto,
+          costruisce box1/2/3 dai dati reali, compone il frontmatter (gray-matter),
+          committa il .md su main
+GitHub Action -> genera l'hero (google -> openrouter -> pollinations, con riferimento di stile)
               -> compone la copertina finale (template rosa + hero + 3 box dati)
-              -> committa il PNG
+              -> committa il PNG (o FALLISCE rumorosamente se l'hero non si genera)
 Vercel        -> deploy automatico -> articolo LIVE
-Hermes        -> recupera la copertina e la manda su Telegram per verifica
-              -> prepara il messaggio pronto da incollare su WhatsApp
+Hermes        -> attende ~90s, verifica che coverUrl risponda 200 (max 4 tentativi)
+              -> manda la copertina su Telegram, poi il messaggio pronto per WhatsApp
 ```
 
-### ✅ Cosa è stato costruito e testato (tutto già su `main`)
+### Variabili d'ambiente da configurare
 
-| Pezzo | File | Stato |
+| Variabile | Dove | A cosa serve |
 |---|---|---|
-| Template grafico copertina (rosa, logo, testata) | `scripts/gazzetta/template.html` | ✅ testato |
-| Motore di rendering PNG (Puppeteer) | `scripts/gazzetta/genera_gazzetta.js` | ✅ testato |
-| Generazione hero da testo (Pollinations, gratis) | `scripts/gazzetta/lib/imagegen.js` | ✅ scritto, non testabile nel sandbox (host bloccato dal proxy), ma è l'endpoint pubblico documentato |
-| Composizione copertina da frontmatter `.md` (usato dalla Action) | `scripts/gazzetta/build_cover_from_md.js` | ✅ testato |
-| GitHub Action che scatta al commit di un articolo | `.github/workflows/gazzetta-cover.yml` | ✅ attiva su `main` (verificato via API GitHub) |
-| Manuale operativo che Hermes legge e segue | `docs/HERMES_PLAYBOOK.md` | ✅ letto con successo da Hermes su `main` |
-| Prompt/voce editoriale (stile Buffa/Ziliani/Pardo, dai tuoi articoli veri) | `scripts/gazzetta/lib/prompt.js` | ✅ (usato dal bot standalone, non da Hermes — vedi nota sotto) |
-| Lettura dati giornata dal foglio | `/api/verdetto` (già esistente) + `scripts/gazzetta/lib/fetchGiornata.js` | ✅ |
-| **Prova end-to-end reale con Hermes** | — | ⚠️ **fatta parzialmente**: Hermes ha scritto un articolo di giornata 38 (stagione 2526, dati reali) col vecchio formato box, la Action ha generato la copertina correttamente. Poi il formato box è cambiato (ora sono dati, non testo) e quel test è stato rimosso dal repo (era di prova). **Va rifatto da capo col formato nuovo.** |
+| `GEMINI_API_KEY` | Secret di GitHub Actions | provider immagine primario (Nano Banana 2) |
+| `OPENROUTER_API_KEY` | Secret di GitHub Actions (e config Hermes, per scrivere l'articolo) | provider immagine di scorta / LLM di Hermes |
+| `GAZZETTA_PUBLISH_SECRET` | Environment Variable di Vercel + config Hermes | autentica `POST /api/gazzetta/publish` |
+| `GAZZETTA_GH_TOKEN` | Environment Variable di Vercel | token GitHub server-side (`contents: write`) per il commit dell'articolo — Hermes non lo vede mai |
+| `GITHUB_REPO_OWNER` / `GITHUB_REPO_NAME` | Environment Variable di Vercel (opzionali, default `dritall`/`fantalaghee`) | repo target del commit |
+| `APPS_SCRIPT_WEBAPP_URL` / `APPS_SCRIPT_SECRET` | config Hermes | trigger ricalcolo foglio |
+| `IMAGE_PROVIDERS`, `IMAGE_STYLE_REFS`, `GEMINI_IMAGE_MODEL`, `OPENROUTER_IMAGE_MODEL`, `IMAGE_SEED` | opzionali, Secret/env di GitHub Actions | override della catena provider e dei riferimenti di stile |
 
-### ❌ Cosa manca davvero (il vero "cosa devo risolvere")
+### Cosa resta da fare prima di andare live
 
-1. **GITHUB_TOKEN per Hermes.** Nell'ultimo tentativo Hermes ha scritto l'articolo ma
-   **non è riuscito a committarlo**: "l'autenticazione MCP GitHub è fallita (nessun token
-   configurato in questa sessione)". Senza un token con permesso di scrittura sul repo
-   `dritall/fantalaghee`, Hermes non può completare il passo 6 del playbook (commit).
-   **Questo è il blocco numero 1, quello che rompe l'automazione end-to-end oggi.**
-   Va risolto configurando l'accesso GitHub nel profilo/ambiente di Hermes (token con
-   permesso `contents: write` su quel repo).
-
-2. **Apps Script pubblicato come Web App** (per il trigger automatico del calcolo giornata).
-   Non risulta ancora confermato che sia stato fatto. Serve:
-   - pubblicare lo script del foglio come Web App (istruzioni già date in questa
-     conversazione: `Estensioni → Apps Script → doGet(e) con token → Distribuisci → App web`)
-   - dare a Hermes `APPS_SCRIPT_WEBAPP_URL` e `APPS_SCRIPT_SECRET`
-   Nota: **non blocca i test** — si può sempre saltare il passo 1 e leggere direttamente
-   `/api/verdetto?stagione=2526` (dati reali archiviati) per provare tutto il resto.
-
-3. **Un test end-to-end completo col formato definitivo** (hero da `image_prompt` + 3 box
-   dati). Non ancora fatto per intero: il test precedente usava il formato vecchio dei box
-   ed è stato rimosso. Da rifare una volta risolto il punto 1.
-
-4. **Qualità/coerenza dell'immagine generata da Pollinations** — mai vista in azione (solo
-   documentata). Da valutare alla prima immagine vera: se lo stile non convince o Pollinations
-   ha limiti di rate/qualità, si passa a un provider a pagamento (pochi centesimi/immagine)
-   cambiando solo `scripts/gazzetta/lib/imagegen.js`.
-
-### Riepilogo in una frase
-
-**Il sistema è scritto, collaudato a pezzi, e Hermes sa leggere le istruzioni e scrivere
-correttamente — l'unica cosa che blocca l'automazione reale oggi è che Hermes non ha ancora
-un permesso di scrittura (token) sul repo GitHub per completare da solo il commit finale.**
-Sistemato quello, si può fare un test end-to-end pulito e poi è operativo.
+1. **Popolare i secret sopra** (`GEMINI_API_KEY`, `OPENROUTER_API_KEY` su GitHub Actions;
+   `GAZZETTA_PUBLISH_SECRET`, `GAZZETTA_GH_TOKEN` su Vercel).
+2. **Un test end-to-end reale** col nuovo endpoint `/api/gazzetta/publish` — non ancora
+   fatto in questa sessione (nessuna chiamata di rete a Gemini/OpenRouter/GitHub è stata
+   fatta durante l'implementazione, per esplicita richiesta: il codice è scritto, non
+   collaudato contro le API vere).
+3. **Aggiornare `APPS_SCRIPT_WEBAPP_URL`/`APPS_SCRIPT_SECRET`** in config Hermes se non
+   già fatto (invariato rispetto a prima).
+4. **Valutare la qualità/coerenza delle prime immagini generate da Nano Banana 2** — mai
+   vista in azione. Se lo stile non convince, si aggiusta `STYLE_SUFFIX` o
+   `STYLE_REF_INSTRUCTION` in `scripts/gazzetta/lib/imagegen.js`, oppure si cambia
+   l'ordine dei provider via `IMAGE_PROVIDERS`.
 
 ---
 

--- a/docs/HERMES_PLAYBOOK.md
+++ b/docs/HERMES_PLAYBOOK.md
@@ -4,36 +4,68 @@ Questo file è il manuale che **Hermes** (l'agente su Telegram) segue per pubbli
 articolo della Gazzetta, dall'inizio alla fine. Hermes deve rileggerlo a ogni esecuzione.
 
 Ruoli:
-- **Hermes**: orchestratore + scrittore. Fa: trigger foglio, lettura dati, scrittura
-  articolo, e scrive un `image_prompt` (in inglese) per l'illustrazione. Commit su GitHub,
-  messaggio WhatsApp. **Hermes NON genera immagini** (non serve FAL_KEY): basta l'image_prompt.
-- **GitHub Action** (`.github/workflows/gazzetta-cover.yml`): GENERA l'illustrazione hero
-  dall'`image_prompt` (Pollinations.ai, gratis) e COMPONE la copertina finale con Puppeteer
-  (template rosa + hero + 3 box dati), poi la committa.
+- **Hermes**: legge lo stato, scrive l'articolo, scrive il prompt dell'illustrazione
+  in inglese (`image_prompt`), manda la bozza su Telegram, poi pubblica con una singola
+  chiamata HTTP. Hermes **non tocca GitHub, non genera immagini, non compila numeri**.
+- **`/api/gazzetta/stato`**: dice se una giornata è pronta da raccontare (calcolato dai
+  dati reali, non da un'attesa a occhio).
+- **`/api/gazzetta/publish`**: riceve la bozza, legge i dati reali di giornata, compila i
+  tre box, scrive il file `.md` e lo committa su `main` — un'unica chiamata sostituisce
+  YAML a mano e commit git.
+- **GitHub Action** (`.github/workflows/gazzetta-cover.yml`): genera l'illustrazione hero
+  dall'`image_prompt` (catena di provider con riferimento alle copertine storiche) e
+  compone la copertina finale con Puppeteer (template rosa + hero + 3 box dati).
 - **Vercel**: pubblica in automatico al push su `main`.
+
+## Cosa Hermes NON fa più
+
+- Non genera immagini (nessun tool `image_generate`, nessuna `FAL_KEY`).
+- Non scrive YAML a mano.
+- Non usa git né l'MCP GitHub: nessun accesso al repo.
+- Non compila i box dati (Top 5, Classifica, Verdetti): li calcola il server dai dati reali.
+- Non chiede all'utente il numero di giornata: lo legge da `/api/gazzetta/stato`.
 
 ---
 
 ## Procedura completa (in ordine)
 
-### 1. Avvio calcolo giornata
-Alla richiesta dell'utente (es. "fai la gazzetta"), chiama la **Web App dell'Apps Script**
-per far ricalcolare la giornata nel foglio:
+### 1. Che giornata è
+
+```
+GET  https://www.fantalaghee.live/api/gazzetta/stato?stagione=2627
+```
+
+Risposta:
+```json
+{
+  "stagione": "2627",
+  "giornata": 7,
+  "pronta": true,
+  "stato": "PRONTA",
+  "motivo": "...",
+  "slugAtteso": "gazzetta-g7",
+  "dettaglio": { "giornataChiusaSerieA": 7, "giornataFoglio": 7, "giornataPubblicata": 6 }
+}
+```
+
+In base a `stato`:
+- **`GIA_PUBBLICATA`** o **`NON_ANCORA`** → riporta `motivo` all'utente su Telegram e fermati.
+- **`FOGLIO_DA_RICALCOLARE`** → vai al passo 2.
+- **`PRONTA`** → vai al passo 3.
+
+### 2. Sveglia il foglio
+
+Chiama la Web App dell'Apps Script per far ricalcolare la giornata:
 
 ```
 GET  {APPS_SCRIPT_WEBAPP_URL}?token={APPS_SCRIPT_SECRET}
 ```
 
-- `APPS_SCRIPT_WEBAPP_URL` e `APPS_SCRIPT_SECRET` sono forniti nella config di Hermes.
-- Se la chiamata risponde con errore, avvisa l'utente e fermati.
+Poi **ricontrolla `/api/gazzetta/stato` ogni 60 secondi finché `pronta` è `true`, massimo
+5 giri**. Non un'attesa fissa: è il codice a dire quando il foglio è pronto, non un timer
+a occhio. Se dopo 5 giri non è ancora `pronta: true`, avvisa l'utente e fermati.
 
-### 2. Attesa (~3 minuti)
-Il foglio impiega qualche minuto a ricalcolare. Attendi ~3 minuti, poi verifica che i dati
-siano pronti (passo 3). Se il numero giornata non è ancora aggiornato, attendi ancora un
-minuto e riprova (max 5 tentativi).
-
-### 3. Lettura dati giornata
-Leggi i dati già calcolati e parsati dall'endpoint del sito (JSON, nessuna credenziale):
+### 3. Scrivi il pezzo
 
 ```
 GET  https://www.fantalaghee.live/api/verdetto?stagione=2627
@@ -41,75 +73,65 @@ GET  https://www.fantalaghee.live/api/verdetto?stagione=2627
 
 Campi utili: `numeroGiornata`, `campioneDiGiornata`, `podio[]`, `classifica[]`,
 `recordAssoluto`, `cucchiaioDiLegno`, `premi.giornata[]`, `leaderAttuale`.
-**Usa solo questi numeri. Non inventare punteggi.**
+**Usa solo questi numeri per il tono dell'articolo. Non inventare punteggi.** I numeri che
+finiscono davvero in copertina non li scrivi tu: li ricalcola il server al passo 4, dagli
+stessi dati.
 
-### 4. Scrittura articolo
 Scrivi l'articolo nello stile della Gazzetta (vedi "Voce editoriale" sotto). Come
 riferimento di stile, leggi SEMPRE 1–2 articoli reali "maturi" dal repo, es.:
 `public/articoli/md/SorpassoSC.md`, `public/articoli/md/gazzetta-finali-coppe.md`.
 
-Produci internamente: `title`, `description`, `body_md` e i dati `cover`
-(titolo_principale, sottotitolo, `image_prompt` per l'illustrazione hero, e i 3 box DATI:
-Top 5 giornata / Classifica generale / Verdetti — riempiti coi numeri reali). Vedi il
-formato al passo 6.
+Produci internamente: `title`, `description`, `body_md`, `cover.titolo_principale`,
+`cover.sottotitolo` e `cover.image_prompt` (in inglese, descrive solo la scena: lo stile
+della testata lo aggiunge automaticamente il generatore di immagini).
 
-### 5. Bozza all'utente (Telegram)
-Manda all'utente il **testo** dell'articolo (title + description + body_md).
-- Se risponde **OK / vai / 👍** → vai al passo 6.
+Manda all'utente su Telegram il **testo** della bozza (title + description + body_md +
+image_prompt).
+- Se risponde **OK / vai / 👍** → vai al passo 4.
 - Se manda **correzioni** → riscrivi applicandole e rimanda la bozza.
 - Se dice di rifare → rigenera da capo.
-NON procedere alla pubblicazione senza l'OK.
 
-### 6. Commit dell'articolo su GitHub
-Crea il file `public/articoli/md/gazzetta-g{N}.md` (N = numero giornata) sul branch `main`,
-con questo frontmatter ESATTO. NON generare nessuna immagine: ti basta scrivere
-`image_prompt` — l'illustrazione la crea la Action da quel prompt.
+**NON procedere alla pubblicazione senza l'OK dell'utente.**
 
-```markdown
----
-title: "Titolo a effetto dell'articolo"
-date: "AAAA-MM-GG"
-description: "Sommario in una frase (max ~160 caratteri)"
-author: "L'Oracolo del Laghèe"
-image: /image/gazzetta/gazzetta-g{N}.png
-cover:
-  giornata: {N}
-  titolo_principale: "MAIUSCOLO, MAX ~50 CARATTERI"
-  sottotitolo: "Sommario della giornata, max ~180 caratteri"
-  image_prompt: "Detailed English prompt for the satirical hero illustration (epic goliardic scene inspired by the round; the champion as a king on a throne, losers with a wooden spoon, Lake Como with boats and mountains; NO readable text)"
-  box1: { title: "🏆 TOP 5 DI GIORNATA", rows: ["1. Squadra|89.5", "2. Squadra|84.5", "3. Squadra|83.0", "4. Squadra|81.5", "5. Squadra|80.0"] }
-  box2: { title: "📊 CLASSIFICA GENERALE", rows: ["1. Squadra|2935.5", "2. Squadra|2930.0", "3. Squadra|2920.0", "4. Squadra|2901.0", "5. Squadra|2889.0"] }
-  box3: { title: "📌 I VERDETTI", rows: ["Campione|Nome", "Record|112.5 Squadra", "Cucchiaio|Squadra 43"] }
----
+### 4. Pubblica
 
-{corpo dell'articolo in Markdown}
+```
+POST https://www.fantalaghee.live/api/gazzetta/publish
+Authorization: Bearer {GAZZETTA_PUBLISH_SECRET}
+Content-Type: application/json
+
+{
+  "title": "...",
+  "description": "Sommario in una frase, max 160 caratteri",
+  "body_md": "corpo dell'articolo in Markdown",
+  "cover": {
+    "titolo_principale": "MAIUSCOLO, MAX 60 CARATTERI",
+    "sottotitolo": "Sommario della giornata, max 180 caratteri",
+    "image_prompt": "Detailed English prompt for the satirical hero illustration"
+  }
+}
 ```
 
-Regole:
-- `image` = `/image/gazzetta/gazzetta-g{N}.png` → è la copertina FINALE, la compone la Action
-  (non crearla tu). NON committare immagini: solo il `.md`.
-- `image_prompt` (in inglese, dettagliato) guida l'illustrazione hero generata dalla Action.
-- I 3 box sono DATI reali presi da `/api/verdetto` (Top 5 giornata, Classifica, Verdetti),
-  non testo libero. Formato riga: "Etichetta|Valore".
-- `date` = data odierna in formato ISO.
-- Il corpo usa `###` per le sezioni, `**grassetto**`, `>` per le profezie dell'Oracolo.
+Non includere `box1`/`box2`/`box3`, `giornata` o `stagione`: il server li ricava da solo
+(li puoi passare solo se stai deliberatamente forzando una giornata specifica, caso raro).
 
-Il commit su `main` fa partire la GitHub Action (che incastona l'hero + i box nella copertina
-finale) e Vercel (deploy).
+Risposte:
+- **`201`** → pubblicato. Contiene `slug`, `commit`, `liveUrl`, `coverUrl`. Vai al passo 5.
+- **`400`** → `dettagli` elenca ogni campo da correggere. Correggi e ripeti la chiamata.
+- **`409`** → l'articolo esiste già o la giornata non è pronta. Riporta `error` all'utente
+  e fermati (non ripetere con `force` senza che l'utente lo chieda esplicitamente).
+- **`401`/`500`** → problema di configurazione lato server. Riporta l'errore e fermati.
 
-### 7. Verifica copertina finale (mandala su Telegram)
-La copertina FINALE (hero + testata + box) la compone la GitHub Action. Dopo il commit:
-- attendi ~90 secondi (tempo di run della Action), poi controlla se l'immagine esiste:
-  `GET https://www.fantalaghee.live/image/gazzetta/gazzetta-g{N}.png` (oppure il file
-  `public/image/gazzetta/gazzetta-g{N}.png` su GitHub, branch `main`).
-- Se risponde 200 / il file esiste → **mandala all'utente su Telegram** come immagine, così
-  può verificarla. Se non c'è ancora, aspetta un altro minuto e riprova (max 4 tentativi).
-- Se dopo i tentativi non compare, avvisa l'utente che la Action potrebbe essere fallita
-  (da controllare nella tab Actions di GitHub) e prosegui comunque col messaggio WhatsApp.
+### 5. Verifica e consegna
 
-### 8. Messaggio WhatsApp (copia/incolla)
-Dopo aver verificato la copertina, manda all'utente su Telegram un messaggio **pronto da
-incollare** nel gruppo WhatsApp. Formato consigliato:
+Attendi ~90 secondi (tempo di run della GitHub Action che genera la copertina), poi
+controlla che `coverUrl` risponda 200 (**max 4 tentativi, un minuto di distanza l'uno
+dall'altro**). Se dopo i tentativi non risponde ancora, avvisa l'utente che la Action
+potrebbe essere fallita (da controllare nella tab Actions di GitHub) e prosegui comunque.
+
+Quando la copertina è pronta:
+1. Mandala su Telegram all'utente per verifica.
+2. Manda il messaggio pronto da incollare su WhatsApp:
 
 ```
 📰 *La Gazzetta del Laghèe* — Giornata {N}
@@ -118,10 +140,8 @@ incollare** nel gruppo WhatsApp. Formato consigliato:
 
 {description}
 
-👉 Leggi tutto: https://www.fantalaghee.live/gazzetta/gazzetta-g{N}
+👉 Leggi tutto: {liveUrl}
 ```
-
-L'articolo è live entro ~1 minuto dal commit (tempo di deploy Vercel + Action immagine).
 
 ---
 
@@ -150,9 +170,12 @@ Italiano. Mai numeri inventati. Il system prompt completo è in `scripts/gazzett
 |---|---|
 | `APPS_SCRIPT_WEBAPP_URL` | URL della Web App dell'Apps Script (trigger calcolo) |
 | `APPS_SCRIPT_SECRET` | token segreto passato alla Web App |
-| accesso GitHub (repo `dritall/fantalaghee`) | committare l'articolo `.md` su `main` |
-| accesso OpenRouter | scrivere l'articolo |
-| capacità di fare richieste HTTP GET | trigger foglio + lettura `/api/verdetto` |
+| `GAZZETTA_PUBLISH_SECRET` | Bearer token per `POST /api/gazzetta/publish` |
+| accesso HTTP GET | trigger foglio + lettura `/api/gazzetta/stato` e `/api/verdetto` |
+| accesso HTTP POST | pubblicazione via `/api/gazzetta/publish` |
+| accesso OpenRouter | scrivere l'articolo (LLM) |
 
-> Nota: NON serve alcun tool di generazione immagini né `FAL_KEY` lato Hermes.
-> L'illustrazione hero la genera la GitHub Action (Pollinations, gratis) dall'`image_prompt`.
+> **Nessun accesso GitHub.** Hermes non ha bisogno di un token GitHub né dell'MCP GitHub:
+> il commit lo fa il server dietro `/api/gazzetta/publish`.
+> Nessun tool di generazione immagini né `FAL_KEY`: l'illustrazione hero la genera la
+> GitHub Action dall'`image_prompt`.

--- a/scripts/gazzetta/build_cover_from_md.js
+++ b/scripts/gazzetta/build_cover_from_md.js
@@ -65,15 +65,11 @@ async function buildOne(mdPath, { force = false } = {}) {
     if (heroMancante && c.image_prompt) {
         const slug = path.basename(mdPath, '.md');
         const genPath = heroFile || imageAbsPath(`/image/gazzetta/${slug}-hero.png`);
-        try {
-            const seed = Number(c.giornata) || undefined;
-            await generateHero(c.image_prompt, genPath, { seed });
-            heroSrc = genPath;
-            console.log(`  ↳ hero generato: ${path.basename(genPath)}`);
-        } catch (e) {
-            console.warn(`  ⚠ generazione hero fallita (${e.message}); copertina senza hero.`);
-            heroSrc = null;
-        }
+        const seedEnv = process.env.IMAGE_SEED;
+        const seed = seedEnv !== undefined && seedEnv !== '' ? Number(seedEnv) : (Number(c.giornata) || undefined);
+        await generateHero(c.image_prompt, genPath, { seed });
+        heroSrc = genPath;
+        console.log(`  ↳ hero generato: ${path.basename(genPath)}`);
     }
 
     const coverData = {
@@ -107,14 +103,26 @@ async function main() {
     }
 
     const generati = [];
+    const errori = [];
     for (const f of files) {
-        const out = await buildOne(f, { force });
-        if (out) generati.push(out);
+        try {
+            const out = await buildOne(f, { force });
+            if (out) generati.push(out);
+        } catch (e) {
+            console.error(`✗ errore su ${path.basename(f)}: ${e.message}`);
+            errori.push(`${path.basename(f)}: ${e.message}`);
+        }
     }
     console.log(`\nFatto. Immagini generate: ${generati.length}`);
     // esporta l'elenco per la Action (per capire se c'è qualcosa da committare)
     if (process.env.GITHUB_OUTPUT) {
         fs.appendFileSync(process.env.GITHUB_OUTPUT, `generated=${generati.length}\n`);
+    }
+
+    if (errori.length > 0) {
+        console.error(`\n${errori.length} copertina/e non generata/e:`);
+        errori.forEach(e => console.error(`  - ${e}`));
+        process.exit(1);
     }
 }
 

--- a/scripts/gazzetta/lib/imagegen.js
+++ b/scripts/gazzetta/lib/imagegen.js
@@ -1,44 +1,191 @@
+#!/usr/bin/env node
 /**
  * Generazione dell'illustrazione hero della copertina.
  *
- * Di default usa Pollinations.ai: gratis, senza chiave API, via semplice URL.
- * Il backend è Flux. In futuro si può passare a un provider a pagamento (FAL, OpenAI)
- * cambiando solo questa funzione e leggendo una chiave da GitHub Secret.
+ * Catena di provider, in ordine (si scende al successivo solo quando quello sopra
+ * ha esaurito i tentativi):
+ *   1. google       - Nano Banana 2 via Gemini API (GEMINI_API_KEY) - primario
+ *   2. openrouter   - Image API unificata (OPENROUTER_API_KEY) - scorta
+ *   3. pollinations - gratis, senza chiave, nessun riferimento di stile - ultima rete
+ *
+ * I provider "google" e "openrouter" ricevono in ingresso, insieme al prompt, due
+ * copertine storiche della testata come riferimento di stile (vedi loadStyleRefs),
+ * così la nuova illustrazione nasce nello stesso linguaggio visivo.
  *
  * Env opzionali:
- *   IMAGE_PROVIDER  - "pollinations" (default)
- *   IMAGE_WIDTH     - default 900
- *   IMAGE_HEIGHT    - default 520
+ *   IMAGE_PROVIDERS      - lista provider separata da virgole (default "google,openrouter,pollinations")
+ *   IMAGE_STYLE_REFS     - lista path (relativi a /public) separata da virgole per i riferimenti di stile
+ *   IMAGE_WIDTH          - default 900 (solo pollinations)
+ *   IMAGE_HEIGHT         - default 520 (solo pollinations)
+ *   GEMINI_API_KEY       - chiave Gemini
+ *   GEMINI_IMAGE_MODEL   - default "gemini-3.1-flash-image"
+ *   OPENROUTER_API_KEY   - chiave OpenRouter
+ *   OPENROUTER_IMAGE_MODEL - default "google/gemini-3.1-flash-image"
+ *
+ * CLI di test (nessuna scrittura nel repo):
+ *   GEMINI_API_KEY=... node scripts/gazzetta/lib/imagegen.js "<prompt>" /tmp/hero.png
  */
 
 const fs = require('fs');
 const path = require('path');
 
+const REPO_ROOT = path.join(__dirname, '../../..');
+const PUBLIC_DIR = path.join(REPO_ROOT, 'public');
+
 const WIDTH = parseInt(process.env.IMAGE_WIDTH || '900', 10);
 const HEIGHT = parseInt(process.env.IMAGE_HEIGHT || '520', 10);
 
-// Suffisso di stile per mantenere coerenza grafica con le vecchie copertine
+const DEFAULT_PROVIDERS = ['google', 'openrouter', 'pollinations'];
+const DEFAULT_STYLE_REFS = [
+    '/image/gazzetta/gazzetta-g30-sorpasso.webp',
+    '/image/gazzetta/gazzetta-g28-triello-onda.webp',
+];
+const DEFAULT_TENTATIVI = 2;
+const SEED_STEP = 1000;
+const MIN_BYTES = 20000;
+
+const GEMINI_MODEL = process.env.GEMINI_IMAGE_MODEL || 'gemini-3.1-flash-image';
+const OPENROUTER_MODEL = process.env.OPENROUTER_IMAGE_MODEL || 'google/gemini-3.1-flash-image';
+
+// Suffisso di stile per mantenere coerenza grafica con le vecchie copertine.
+// Descrive la testata (non la scena, che la scrive Hermes nel prompt).
 const STYLE_SUFFIX =
-    'vintage satirical sports newspaper editorial illustration, hand-drawn colored ink style, ' +
-    'epic and humorous scene set on Lake Como (Lario) with mountains and rowing boats, ' +
-    'dramatic lighting, rich detail, NO readable text, no watermark';
+    'Editorial satirical illustration for the front page of a fantasy-football newspaper. ' +
+    'Hand-drawn colored ink linework, vintage sports-newspaper flavor. ' +
+    'Warm color palette that reads well on pale pink newsprint. ' +
+    'Setting: Lake Como (Lario) - steep mountains, rowing boats, lakeside villages. ' +
+    'Epic and goliardic tone, never mean-spirited. Single focal subject. ' +
+    'Loose free edges suitable for cropping. ' +
+    'NO text, letters, numbers, watermark, signature or logo of any kind.';
+
+// Istruzione testuale che accompagna i riferimenti di stile (solo google/openrouter)
+const STYLE_REF_INSTRUCTION =
+    'The attached images are past covers of "La Gazzetta del Laghèe", a satirical fantasy-football ' +
+    'newspaper. Study their hand-drawn ink style, color palette, line weight and humorous register, ' +
+    'and carry that same visual language into the new illustration. Do NOT reuse their subject or ' +
+    'composition: those come only from the scene prompt below.';
+
+const MIME_BY_EXT = { '.webp': 'image/webp', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg' };
 
 /**
- * Genera l'hero da un prompt e lo salva su outPath.
- * @param {string} prompt - descrizione (in inglese) della scena
- * @param {string} outPath - percorso assoluto del file immagine da scrivere
- * @param {object} [opts]
- * @param {number} [opts.seed] - seed per riproducibilità
- * @returns {Promise<string>} outPath
+ * Carica le copertine storiche di riferimento come base64, per guidare lo stile.
+ * Salta silenziosamente i file mancanti; se non ne resta nessuno logga un avviso.
+ * @returns {{mime: string, data: string, path: string}[]}
  */
-async function generateHero(prompt, outPath, opts = {}) {
-    const provider = process.env.IMAGE_PROVIDER || 'pollinations';
-    if (provider !== 'pollinations') {
-        throw new Error(`IMAGE_PROVIDER "${provider}" non supportato (per ora solo pollinations).`);
+function loadStyleRefs() {
+    const refs = process.env.IMAGE_STYLE_REFS
+        ? process.env.IMAGE_STYLE_REFS.split(',').map(s => s.trim()).filter(Boolean)
+        : DEFAULT_STYLE_REFS;
+
+    const out = [];
+    for (const rel of refs) {
+        const filePath = path.join(PUBLIC_DIR, rel.replace(/^\//, ''));
+        if (!fs.existsSync(filePath)) continue;
+        const ext = path.extname(filePath).toLowerCase();
+        const mime = MIME_BY_EXT[ext] || 'image/webp';
+        out.push({ mime, data: fs.readFileSync(filePath).toString('base64'), path: filePath });
+    }
+    if (out.length === 0) {
+        console.warn('⚠ Nessun riferimento di stile trovato: la coerenza grafica con le copertine storiche non è garantita.');
+    }
+    return out;
+}
+
+/** Valida il buffer immagine: dimensione minima e magic bytes di PNG/JPEG/WEBP. */
+function isValidImageBuffer(buf) {
+    if (!buf || buf.length < MIN_BYTES) return false;
+    if (buf[0] === 0x89 && buf[1] === 0x50) return true; // PNG
+    if (buf[0] === 0xff && buf[1] === 0xd8) return true; // JPEG
+    if (buf.slice(0, 4).toString('ascii') === 'RIFF') return true; // WEBP
+    return false;
+}
+
+// --- Provider: Google (Nano Banana 2 via Gemini API) ---
+
+async function generaConGoogle(prompt, seed, styleRefs) {
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) throw new Error('GEMINI_API_KEY non configurata');
+
+    const parts = [{ text: STYLE_REF_INSTRUCTION }];
+    for (const ref of styleRefs) {
+        parts.push({ inline_data: { mime_type: ref.mime, data: ref.data } });
+    }
+    parts.push({ text: `${prompt} ${STYLE_SUFFIX}` });
+
+    const url = `https://generativelanguage.googleapis.com/v1/models/${GEMINI_MODEL}:generateContent`;
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'x-goog-api-key': apiKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            contents: [{ role: 'user', parts }],
+            generationConfig: {
+                responseModalities: ['TEXT', 'IMAGE'],
+                imageConfig: { aspectRatio: '16:9', imageSize: '1K' },
+                seed,
+            },
+        }),
+    });
+
+    if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`Gemini ha risposto ${res.status}: ${body.slice(0, 300)}`);
     }
 
-    const fullPrompt = `${prompt}. ${STYLE_SUFFIX}`;
-    const seed = opts.seed ?? Math.floor(Math.random() * 1e6);
+    const json = await res.json();
+    const cand = json?.candidates?.[0];
+    const resParts = cand?.content?.parts || [];
+    for (const p of resParts) {
+        const inline = p.inlineData || p.inline_data;
+        if (inline?.data) return Buffer.from(inline.data, 'base64');
+    }
+    throw new Error(`Gemini non ha restituito un'immagine (finishReason: ${cand?.finishReason || 'sconosciuto'})`);
+}
+
+// --- Provider: OpenRouter Image API (scorta) ---
+
+async function generaConOpenRouter(prompt, seed, styleRefs) {
+    const apiKey = process.env.OPENROUTER_API_KEY;
+    if (!apiKey) throw new Error('OPENROUTER_API_KEY non configurata');
+
+    const body = {
+        model: OPENROUTER_MODEL,
+        prompt: `${prompt} ${STYLE_SUFFIX}`,
+        aspect_ratio: '16:9',
+        resolution: '1K',
+        output_format: 'png',
+        seed,
+    };
+    if (styleRefs.length > 0) {
+        body.input_references = styleRefs.map(ref => ({
+            type: 'image_url',
+            image_url: { url: `data:${ref.mime};base64,${ref.data}` },
+        }));
+    }
+
+    const res = await fetch('https://openrouter.ai/api/v1/images', {
+        method: 'POST',
+        headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+        const errBody = await res.text().catch(() => '');
+        throw new Error(`OpenRouter ha risposto ${res.status}: ${errBody.slice(0, 300)}`);
+    }
+
+    const json = await res.json();
+    const b64 = json?.data?.[0]?.b64_json;
+    if (!b64) throw new Error('OpenRouter non ha restituito b64_json');
+    if (json?.usage?.cost != null) {
+        console.log(`  ↳ costo generazione OpenRouter: $${json.usage.cost}`);
+    }
+    return Buffer.from(b64, 'base64');
+}
+
+// --- Provider: Pollinations (gratis, senza chiave, nessun riferimento di stile) ---
+
+async function generaConPollinations(prompt, seed) {
+    const fullPrompt = `${prompt} ${STYLE_SUFFIX}`;
     const url = `https://image.pollinations.ai/prompt/${encodeURIComponent(fullPrompt)}`
         + `?width=${WIDTH}&height=${HEIGHT}&nologo=true&model=flux&seed=${seed}&referrer=fantalaghee`;
 
@@ -46,13 +193,70 @@ async function generateHero(prompt, outPath, opts = {}) {
     if (!res.ok) {
         throw new Error(`Pollinations ha risposto ${res.status} ${res.statusText}`);
     }
-    const buf = Buffer.from(await res.arrayBuffer());
-    if (buf.length < 1000) {
-        throw new Error(`Immagine generata troppo piccola (${buf.length} byte): probabile errore.`);
-    }
-    fs.mkdirSync(path.dirname(outPath), { recursive: true });
-    fs.writeFileSync(outPath, buf);
-    return outPath;
+    return Buffer.from(await res.arrayBuffer());
 }
 
-module.exports = { generateHero };
+const PROVIDERS = {
+    google: generaConGoogle,
+    openrouter: generaConOpenRouter,
+    pollinations: (prompt, seed) => generaConPollinations(prompt, seed),
+};
+
+/**
+ * Genera l'hero da un prompt, provando la catena di provider in ordine, e lo salva su outPath.
+ * @param {string} prompt - descrizione (in inglese) della scena
+ * @param {string} outPath - percorso assoluto del file immagine da scrivere
+ * @param {object} [opts]
+ * @param {number} [opts.seed] - seed base per riproducibilità (incrementato di 1000 a ogni tentativo)
+ * @param {number} [opts.tentativi] - tentativi per provider (default 2)
+ * @returns {Promise<string>} outPath
+ */
+async function generateHero(prompt, outPath, opts = {}) {
+    const providers = process.env.IMAGE_PROVIDERS
+        ? process.env.IMAGE_PROVIDERS.split(',').map(s => s.trim()).filter(Boolean)
+        : DEFAULT_PROVIDERS;
+    const tentativi = opts.tentativi ?? DEFAULT_TENTATIVI;
+    const seedBase = opts.seed ?? Math.floor(Math.random() * 1e6);
+    const styleRefs = loadStyleRefs();
+
+    const errori = [];
+    for (const nome of providers) {
+        const fn = PROVIDERS[nome];
+        if (!fn) {
+            errori.push(`${nome}: provider sconosciuto`);
+            continue;
+        }
+        for (let i = 0; i < tentativi; i++) {
+            const seed = seedBase + i * SEED_STEP;
+            try {
+                const buf = await fn(prompt, seed, styleRefs);
+                if (!isValidImageBuffer(buf)) {
+                    throw new Error(`buffer non valido (${buf ? buf.length : 0} byte)`);
+                }
+                fs.mkdirSync(path.dirname(outPath), { recursive: true });
+                fs.writeFileSync(outPath, buf);
+                console.log(`✓ hero generato con ${nome} (tentativo ${i + 1}/${tentativi}, seed ${seed})`);
+                return outPath;
+            } catch (e) {
+                console.warn(`⚠ ${nome} tentativo ${i + 1}/${tentativi} fallito: ${e.message}`);
+                errori.push(`${nome} (tentativo ${i + 1}): ${e.message}`);
+            }
+        }
+    }
+
+    throw new Error(`Tutti i provider immagine sono falliti:\n${errori.join('\n')}`);
+}
+
+module.exports = { generateHero, loadStyleRefs, STYLE_SUFFIX };
+
+// --- CLI: `node imagegen.js "<prompt>" <outPath>` - prova un prompt senza toccare il repo ---
+if (require.main === module) {
+    const [, , prompt, outPath] = process.argv;
+    if (!prompt || !outPath) {
+        console.error('Uso: node scripts/gazzetta/lib/imagegen.js "<prompt>" <outPath>');
+        process.exit(1);
+    }
+    generateHero(prompt, outPath)
+        .then(p => console.log(`✓ Immagine salvata: ${p}`))
+        .catch(err => { console.error(err.message); process.exit(1); });
+}


### PR DESCRIPTION
## Summary
- Riscritta `scripts/gazzetta/lib/imagegen.js`: catena provider `google` (Nano Banana 2) → `openrouter` → `pollinations`, con riferimenti di stile dalle copertine storiche e controllo qualità del buffer generato.
- Nuovo `app/api/gazzetta/stato/route.ts`: incrocia calendario Serie A, foglio Google e filesystem per dire se una giornata è pronta da raccontare, eliminando l'attesa "a occhio".
- Nuovo `app/api/gazzetta/publish/route.ts`: riceve la bozza testuale di Hermes, ricalcola i tre box dati da `/api/verdetto` (mai dal payload), compone il frontmatter con `gray-matter` e committa l'articolo su `main` via GitHub Contents API, autenticato con `GAZZETTA_PUBLISH_SECRET`.
- Corretto `scripts/gazzetta/build_cover_from_md.js`: un blocco `cover` con generazione hero fallita ora fa fallire lo script (`exit 1`) invece di pubblicare in silenzio una copertina senza illustrazione; aggiunto supporto a `IMAGE_SEED`.
- Aggiornato `.github/workflows/gazzetta-cover.yml`: chiavi immagine solo sullo step di build, input manuali `slug`/`seed`/`force` su `workflow_dispatch`, nessun mascheramento di errori.
- Riscritti `docs/HERMES_PLAYBOOK.md` (5 passi invece di 8, zero YAML/git per Hermes) e la sezione di stato di `docs/AUTOMAZIONE_GAZZETTA.md`.

## Test plan
- [x] `node --check` su entrambi gli script JS modificati
- [x] `loadStyleRefs()` restituisce le 2 copertine storiche di riferimento
- [x] Verificato con harness isolato (stub locali, zero rete): `.md` senza `cover` → salto, exit 0; `.md` con `cover` e generazione fallita → exit 1; `IMAGE_SEED` sovrascrive il seed passato a `generateHero`
- [ ] `npx tsc --noEmit` non eseguibile in sandbox (dipendenze non installate) — da verificare in CI
- [ ] Test end-to-end reale contro Gemini/OpenRouter/GitHub — da fare una volta configurati i secret (vedi `docs/AUTOMAZIONE_GAZZETTA.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hzpc5HYbx21adNFVR91GPy)_