### PR TITLE
Corregge illustrazione hero mancante nella copertina

### DIFF
--- a/scripts/gazzetta/build_cover_from_md.js
+++ b/scripts/gazzetta/build_cover_from_md.js
@@ -56,7 +56,7 @@ async function buildOne(mdPath, { force = false } = {}) {
 
     // Risoluzione dell'HERO:
     // 1) se Hermes ha già fornito/committato un file hero -> lo usiamo;
-    // 2) altrimenti, se c'è image_prompt -> lo generiamo qui (Pollinations, gratis) e lo salviamo;
+    // 2) altrimenti, se c'è image_prompt -> lo generiamo qui e lo salviamo;
     // 3) altrimenti -> nessun hero (placeholder).
     let heroSrc = c.hero_image || c.img_principale || null;
     const heroFile = heroSrc && heroSrc.startsWith('/') ? imageAbsPath(heroSrc) : null;
@@ -64,11 +64,18 @@ async function buildOne(mdPath, { force = false } = {}) {
 
     if (heroMancante && c.image_prompt) {
         const slug = path.basename(mdPath, '.md');
-        const genPath = heroFile || imageAbsPath(`/image/gazzetta/${slug}-hero.png`);
+        // heroUrl è la forma PUBBLICO-relativa (es. /image/gazzetta/gazzetta-g7-hero.png):
+        // è quella che renderCover/toImgSrc risolvono correttamente. genPath (assoluto)
+        // serve SOLO per scrivere il file su disco. Attenzione: NON passare genPath come
+        // img_principale, perché toImgSrc interpreta ogni stringa che inizia con "/" come
+        // relativa a /public e con un path assoluto non troverebbe il file, rendendo il
+        // placeholder al posto dell'illustrazione.
+        const heroUrl = heroSrc && heroSrc.startsWith('/') ? heroSrc : `/image/gazzetta/${slug}-hero.png`;
+        const genPath = imageAbsPath(heroUrl);
         const seedEnv = process.env.IMAGE_SEED;
         const seed = seedEnv !== undefined && seedEnv !== '' ? Number(seedEnv) : (Number(c.giornata) || undefined);
         await generateHero(c.image_prompt, genPath, { seed });
-        heroSrc = genPath;
+        heroSrc = heroUrl;
         console.log(`  ↳ hero generato: ${path.basename(genPath)}`);
     }
 


### PR DESCRIPTION
## Summary
Bug osservato al primo test end-to-end reale (giornata 999): l'hero **veniva generato correttamente** (Gemini/Nano Banana 2, file `gazzetta-g999-hero.png` da 922 KB) ma **non compariva nella copertina**, che mostrava il placeholder "IMMAGINE PRINCIPALE".

Causa: `build_cover_from_md.js` passava a `renderCover` il **percorso assoluto** del file hero. `toImgSrc` (in `genera_gazzetta.js`) interpreta ogni stringa che inizia con `/` come relativa a `/public`, quindi con un percorso assoluto non trovava il file e rendeva il placeholder.

Fix: `img_principale` ora riceve la forma **pubblico-relativa** (`/image/gazzetta/{slug}-hero.png`), che `toImgSrc` risolve correttamente; il percorso assoluto resta usato solo per scrivere il file su disco. Nessuna modifica a `genera_gazzetta.js` (fuori scope).

## Test plan
- [x] `node --check` su `build_cover_from_md.js`
- [x] Verificato con harness isolato (stub locali, zero rete): `generateHero` scrive sul path assoluto, ma `renderCover` riceve ora `img_principale = "/image/gazzetta/{slug}-hero.png"` (pubblico-relativo)
- [ ] Verifica reale dopo il merge: rigenerare la copertina g999 via `workflow_dispatch` (slug `gazzetta-g999`, force `true`) e controllare che l'hero compaia

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hzpc5HYbx21adNFVR91GPy)_