### PR TITLE
Conferma testo+immagine, rigenerazione copertina e stile fumetto

### DIFF
--- a/app/api/gazzetta/rigenera-copertina/route.ts
+++ b/app/api/gazzetta/rigenera-copertina/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from 'next/server';
+import crypto from 'crypto';
+
+export const runtime = 'nodejs';
+
+const GITHUB_API = 'https://api.github.com';
+const WORKFLOW_FILE = 'gazzetta-cover.yml';
+
+/** Confronto a tempo costante tra il token ricevuto e il secret configurato. */
+function autenticato(request: NextRequest, secret: string): boolean {
+    const header = request.headers.get('authorization') || '';
+    const match = header.match(/^Bearer\s+(.+)$/);
+    const fornito = match ? match[1] : '';
+    const a = Buffer.from(fornito);
+    const b = Buffer.from(secret);
+    if (a.length !== b.length) return false;
+    return crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * Rigenera la copertina di un articolo già pubblicato con un seed diverso, così Hermes
+ * può proporre una variante dell'illustrazione senza che l'utente debba aprire GitHub.
+ *
+ * Non genera l'immagine qui: fa partire la GitHub Action gazzetta-cover.yml (che ha le
+ * chiavi immagine) via workflow_dispatch, passandole slug + seed + force. In questo modo
+ * nessuna chiave immagine deve stare su Vercel.
+ *
+ * Body: { slug?: string, giornata?: number, seed?: number }
+ * - almeno uno tra slug e giornata (slug ha la precedenza).
+ * - seed assente -> ne genera uno casuale (serve un seed nuovo per avere un'immagine diversa).
+ */
+export async function POST(request: NextRequest) {
+    const publishSecret = process.env.GAZZETTA_PUBLISH_SECRET;
+    if (!publishSecret) {
+        return NextResponse.json(
+            { ok: false, error: 'GAZZETTA_PUBLISH_SECRET non configurato sul server.' },
+            { status: 500 }
+        );
+    }
+    if (!autenticato(request, publishSecret)) {
+        return NextResponse.json({ ok: false, error: 'Autenticazione mancante o non valida.' }, { status: 401 });
+    }
+
+    const ghToken = process.env.GAZZETTA_GH_TOKEN;
+    if (!ghToken) {
+        return NextResponse.json(
+            { ok: false, error: 'GAZZETTA_GH_TOKEN non configurato sul server.' },
+            { status: 500 }
+        );
+    }
+
+    let payload: any = {};
+    try {
+        const testo = await request.text();
+        if (testo) payload = JSON.parse(testo);
+    } catch {
+        return NextResponse.json({ ok: false, error: 'Corpo della richiesta non è JSON valido.' }, { status: 400 });
+    }
+
+    let slug: string | null = typeof payload.slug === 'string' && payload.slug.trim() ? payload.slug.trim() : null;
+    if (!slug) {
+        if (typeof payload.giornata === 'number' && Number.isInteger(payload.giornata) && payload.giornata > 0) {
+            slug = `gazzetta-g${payload.giornata}`;
+        } else {
+            return NextResponse.json(
+                { ok: false, error: 'Indica quale copertina rigenerare: passa "slug" (es. gazzetta-g7) oppure "giornata".' },
+                { status: 400 }
+            );
+        }
+    }
+    if (!/^gazzetta-g\d+$/.test(slug)) {
+        return NextResponse.json(
+            { ok: false, error: `Slug non valido: "${slug}". Atteso il formato gazzetta-g{numero}.` },
+            { status: 400 }
+        );
+    }
+
+    // Seed nuovo -> immagine diversa. Se il chiamante non lo passa, ne generiamo uno casuale.
+    const seed = (typeof payload.seed === 'number' && Number.isInteger(payload.seed))
+        ? payload.seed
+        : Math.floor(Math.random() * 1_000_000);
+
+    const owner = process.env.GITHUB_REPO_OWNER || 'dritall';
+    const repo = process.env.GITHUB_REPO_NAME || 'fantalaghee';
+
+    const res = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/actions/workflows/${WORKFLOW_FILE}/dispatches`, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${ghToken}`,
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'fantalaghee-publish',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            ref: 'main',
+            // gli input di workflow_dispatch sono sempre stringhe
+            inputs: { slug, seed: String(seed), force: 'true' },
+        }),
+    });
+
+    if (res.status === 403) {
+        return NextResponse.json(
+            {
+                ok: false,
+                error: 'Il token GitHub non ha il permesso di avviare le Action (Actions: write). '
+                    + 'Con un token classic "repo" è incluso; con un fine-grained aggiungi "Actions: Read and write". '
+                    + 'In alternativa rigenera la copertina a mano dalla tab Actions di GitHub (Run workflow).',
+            },
+            { status: 403 }
+        );
+    }
+    if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        return NextResponse.json(
+            { ok: false, error: `Avvio della rigenerazione fallito (${res.status}): ${body.slice(0, 300)}` },
+            { status: 502 }
+        );
+    }
+
+    // workflow_dispatch risponde 204 senza corpo
+    return NextResponse.json({
+        ok: true,
+        slug,
+        seed,
+        messaggio: `Rigenerazione della copertina ${slug} avviata (seed ${seed}). `
+            + `Attendi ~90 secondi, poi ricontrolla https://www.fantalaghee.live/image/gazzetta/${slug}.png`,
+    });
+}

--- a/docs/AUTOMAZIONE_GAZZETTA.md
+++ b/docs/AUTOMAZIONE_GAZZETTA.md
@@ -5,6 +5,30 @@
 > le sessioni di Claude Code non condividono memoria tra loro. Leggi prima questo file,
 > poi continua da qui.
 
+## ➕ Aggiunta (30 luglio 2026) — conferma testo+immagine e rigenerazione copertina
+
+Su richiesta: Hermes non pubblica più "di slancio". Ora il flusso ha **due conferme**
+esplicite — prima sul testo (prima di pubblicare), poi sull'immagine (dopo che la Action
+ha composto la copertina). L'articolo viene committato prima di vedere l'immagine, ma non
+viene condiviso (WhatsApp) finché l'utente non approva anche la copertina.
+
+Per far provare varianti dell'illustrazione **senza dare a Hermes accesso a GitHub e senza
+mettere le chiavi immagine su Vercel**, è stato aggiunto **`POST /api/gazzetta/rigenera-copertina`**
+(`app/api/gazzetta/rigenera-copertina/route.ts`): stessa autenticazione
+(`GAZZETTA_PUBLISH_SECRET`), lato server fa partire la GitHub Action `gazzetta-cover.yml`
+via `workflow_dispatch` con `slug` + un **seed nuovo** + `force`, usando `GAZZETTA_GH_TOKEN`
+(già su Vercel). L'immagine continua a generarla la Action, dove le chiavi
+`GEMINI_API_KEY`/`OPENROUTER_API_KEY` già vivono. Nota: il token deve poter avviare le
+Action (un token classic con scope `repo` lo può; un fine-grained richiede "Actions:
+Read and write") — altrimenti l'endpoint risponde `403` con istruzioni.
+
+Rifinita anche la resa dell'illustrazione (`scripts/gazzetta/lib/imagegen.js`): stile spinto
+verso la **caricatura a fumetto ricca e colorata** delle copertine storiche (non minimal/
+pittorica) e riferimenti di stile di default aggiornati a tre copertine reali
+(`edizione-straordinaria-2627`, `trilogia-del-potere`, `speciale-giro-di-boa`).
+
+---
+
 ## ➕ Aggiunta (29 luglio 2026) — cancellazione articolo, a due passi
 
 Su richiesta dell'utente (comodo per pulire un test pubblicato senza una nuova giornata

--- a/docs/HERMES_PLAYBOOK.md
+++ b/docs/HERMES_PLAYBOOK.md
@@ -85,13 +85,24 @@ Produci internamente: `title`, `description`, `body_md`, `cover.titolo_principal
 `cover.sottotitolo` e `cover.image_prompt` (in inglese, descrive solo la scena: lo stile
 della testata lo aggiunge automaticamente il generatore di immagini).
 
+**L'`image_prompt` usa i nomi VERI delle squadre presi da `/api/verdetto`** (campione,
+podio, cucchiaio di legno…), mai nomi inventati: così la caricatura ritrae le squadre
+giuste della giornata (es. il campione sul trono è la squadra reale, il cucchiaio di legno
+ha il mestolo, ecc.). Puoi attingere ai **motivi ricorrenti** della testata: il cucciolo
+"Cuccioloni", il razzo "Stoke Azzo", il lupo, la pioggia di melanzane 🍆, il trono, il lago
+di Como con barca a remi, l'auto d'epoca "Brianza". Un solo soggetto focale chiaro. Niente
+testo leggibile nell'immagine (le scritte le mette il template).
+
+### 3b. Conferma del TESTO (obbligatoria)
+
 Manda all'utente su Telegram il **testo** della bozza (title + description + body_md +
-image_prompt).
+image_prompt) e chiedi esplicitamente: **«Pubblico così? Vuoi modificare qualcosa (dimmi
+cosa)? O rifaccio?»**
 - Se risponde **OK / vai / 👍** → vai al passo 4.
 - Se manda **correzioni** → riscrivi applicandole e rimanda la bozza.
 - Se dice di rifare → rigenera da capo.
 
-**NON procedere alla pubblicazione senza l'OK dell'utente.**
+**NON procedere alla pubblicazione senza un OK esplicito dell'utente sul testo.**
 
 ### 4. Pubblica
 
@@ -122,16 +133,39 @@ Risposte:
   e fermati (non ripetere con `force` senza che l'utente lo chieda esplicitamente).
 - **`401`/`500`** → problema di configurazione lato server. Riporta l'errore e fermati.
 
-### 5. Verifica e consegna
+### 5. Conferma dell'IMMAGINE (obbligatoria)
 
 Attendi ~90 secondi (tempo di run della GitHub Action che genera la copertina), poi
 controlla che `coverUrl` risponda 200 (**max 4 tentativi, un minuto di distanza l'uno
 dall'altro**). Se dopo i tentativi non risponde ancora, avvisa l'utente che la Action
-potrebbe essere fallita (da controllare nella tab Actions di GitHub) e prosegui comunque.
+potrebbe essere fallita (da controllare nella tab Actions di GitHub) e fermati.
 
-Quando la copertina è pronta:
-1. Mandala su Telegram all'utente per verifica.
-2. Manda il messaggio pronto da incollare su WhatsApp:
+Quando la copertina è pronta, **mandala su Telegram** e chiedi: **«Ti va bene questa
+copertina, o ne rigenero un'altra variante?»**
+
+- Se l'utente **approva** → vai al passo 6.
+- Se l'utente **vuole una variante** (o dice che l'immagine non va) → chiama:
+
+  ```
+  POST https://www.fantalaghee.live/api/gazzetta/rigenera-copertina
+  Authorization: Bearer {GAZZETTA_PUBLISH_SECRET}
+  Content-Type: application/json
+
+  { "giornata": 7 }
+  ```
+
+  Il server fa ripartire la generazione con un **seed diverso** (non serve passare il seed:
+  lo sceglie lui e te lo torna). Poi ri-attendi ~90 secondi, ricontrolla `coverUrl` e
+  rimanda la nuova copertina. Ripeti finché l'utente approva.
+  - `403` → il token GitHub non può avviare le Action: riporta il messaggio (l'utente può
+    rigenerare a mano dalla tab Actions) e prosegui col passo 6 se l'immagine attuale basta.
+
+**NON mandare il messaggio WhatsApp (passo 6) finché l'utente non ha approvato l'immagine.**
+L'articolo è già online, ma non va condiviso finché testo e immagine non sono ok.
+
+### 6. Consegna (solo dopo l'OK su testo E immagine)
+
+Manda all'utente il messaggio pronto da incollare su WhatsApp:
 
 ```
 📰 *La Gazzetta del Laghèe* — Giornata {N}
@@ -195,6 +229,18 @@ Highlight colorati con `<span style="color:...">` per i momenti salienti: oro `#
 
 Italiano. Mai numeri inventati. Il system prompt completo è in `scripts/gazzetta/lib/prompt.js`.
 
+### Regole di misura (rispettale sempre)
+
+- **Mai scrivere "Euro" o il simbolo `€`** per i premi. Se proprio devi indicare un premio
+  in denaro, usa l'emoji della melanzana 🍆 (è la valuta scherzosa della testata), oppure
+  gira la frase evitando la cifra.
+- **Niente superlativi gratuiti**: "epico", "mostruoso", "leggendario", "storico",
+  "clamoroso" solo se sono **letteralmente veri** per quella giornata (un vero record, un
+  vero sorpasso in vetta). Se la giornata è normale, raccontala normale.
+- **Riferimenti al lago con misura**: i toponimi lariani e le metafore d'acqua sono il
+  sapore della testata, ma **usane pochi**, non in ogni frase. Meglio uno calzante che
+  cinque a raffica.
+
 ---
 
 ## Config necessaria a Hermes
@@ -203,9 +249,9 @@ Italiano. Mai numeri inventati. Il system prompt completo è in `scripts/gazzett
 |---|---|
 | `APPS_SCRIPT_WEBAPP_URL` | URL della Web App dell'Apps Script (trigger calcolo) |
 | `APPS_SCRIPT_SECRET` | token segreto passato alla Web App |
-| `GAZZETTA_PUBLISH_SECRET` | Bearer token per `POST /api/gazzetta/publish` |
+| `GAZZETTA_PUBLISH_SECRET` | Bearer token per `POST`/`DELETE` `/api/gazzetta/publish` e `POST /api/gazzetta/rigenera-copertina` |
 | accesso HTTP GET | trigger foglio + lettura `/api/gazzetta/stato` e `/api/verdetto` |
-| accesso HTTP POST | pubblicazione via `/api/gazzetta/publish` |
+| accesso HTTP POST | pubblicazione, rigenerazione copertina |
 | accesso OpenRouter | scrivere l'articolo (LLM) |
 
 > **Nessun accesso GitHub.** Hermes non ha bisogno di un token GitHub né dell'MCP GitHub:

--- a/scripts/gazzetta/lib/imagegen.js
+++ b/scripts/gazzetta/lib/imagegen.js
@@ -36,9 +36,12 @@ const WIDTH = parseInt(process.env.IMAGE_WIDTH || '900', 10);
 const HEIGHT = parseInt(process.env.IMAGE_HEIGHT || '520', 10);
 
 const DEFAULT_PROVIDERS = ['google', 'openrouter', 'pollinations'];
+// Copertine storiche di riferimento: sono quelle nello stile fumetto-caricatura ricco e
+// affollato che vogliamo imitare. Sovrascrivibili con IMAGE_STYLE_REFS.
 const DEFAULT_STYLE_REFS = [
-    '/image/gazzetta/gazzetta-g30-sorpasso.webp',
-    '/image/gazzetta/gazzetta-g28-triello-onda.webp',
+    '/image/gazzetta/edizione-straordinaria-2627.webp',
+    '/image/gazzetta/trilogia-del-potere.webp',
+    '/image/gazzetta/speciale-giro-di-boa.webp',
 ];
 const DEFAULT_TENTATIVI = 2;
 const SEED_STEP = 1000;
@@ -56,26 +59,27 @@ const OPENROUTER_RESOLUTION = process.env.OPENROUTER_RESOLUTION || '2K';
 
 // Suffisso di stile per mantenere coerenza grafica con le vecchie copertine.
 // Descrive la testata (non la scena, che la scrive Hermes nel prompt).
-// Spinge su fumetto/cartoon a tratto netto e colori piatti, per assomigliare alle
-// copertine storiche disegnate a mano invece che a un'illustrazione pittorica/realistica.
+// Le copertine storiche sono caricature a fumetto RICCHE, dettagliate e super colorate
+// (non minimal/piatte): il suffisso spinge esattamente in quella direzione.
 const STYLE_SUFFIX =
-    'Editorial satirical cartoon illustration for the front page of a fantasy-football newspaper. ' +
-    'Bold hand-inked comic linework with clean confident outlines, flat limited color fills, ' +
-    'vintage comic-poster / graphic-novel look - NOT painterly, NOT photorealistic, NO 3D render. ' +
-    'Warm color palette that reads well on pale pink newsprint. ' +
-    'Setting: Lake Como (Lario) - steep mountains, rowing boats, lakeside villages. ' +
-    'Epic and goliardic caricature tone, never mean-spirited. Single clear focal subject, ' +
-    'strong readable silhouette, uncluttered background. ' +
-    'Loose free edges suitable for cropping. ' +
-    'NO text, letters, numbers, watermark, signature or logo of any kind.';
+    'Detailed full-color comic caricature illustration for the front page of a satirical ' +
+    'fantasy-football newspaper. Richly detailed hand-drawn editorial cartoon like classic ' +
+    'satirical sports comics: bold clean ink outlines, saturated full colors with shading and ' +
+    'highlights, exaggerated caricatured characters and mascots with big expressions, lively and ' +
+    'busy but readable composition. Setting: Lake Como (Lario) with mountains, a rowing boat and ' +
+    'lakeside villages in the background. Goliardic playful humor, never mean-spirited. ' +
+    'This is a DRAWN COLORED COMIC - NOT flat or minimalist, NOT painterly-realistic, NOT a 3D render. ' +
+    'Clear focal subject. Loose free edges suitable for cropping. ' +
+    'NO readable text, letters, numbers, watermark, signature or logo of any kind.';
 
 // Istruzione testuale che accompagna i riferimenti di stile (solo google/openrouter)
 const STYLE_REF_INSTRUCTION =
     'The attached images are past covers of "La Gazzetta del Laghèe", a satirical fantasy-football ' +
-    'newspaper. Match their hand-drawn comic-cartoon style closely: the same bold ink outlines, ' +
-    'flat color fills, limited warm palette, line weight and humorous caricature register. ' +
-    'Keep it a drawn cartoon, not a painting or a photo. Do NOT reuse their subject or ' +
-    'composition: those come only from the scene prompt below.';
+    'newspaper. Match their style very closely: the same richly detailed, full-color hand-drawn ' +
+    'comic caricature look, bold ink outlines, saturated colors with shading, exaggerated character ' +
+    'faces, recurring mascots and lively busy composition. Keep it a drawn colored comic (not a ' +
+    'painting, not a photo, not a 3D render). Do NOT copy their exact subject or layout: the scene ' +
+    'comes only from the prompt below.';
 
 const MIME_BY_EXT = { '.webp': 'image/webp', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg' };
 


### PR DESCRIPTION
## Summary
Rifiniture richieste dopo i test reali, **senza aggiungere chiavi immagine su Vercel**:

- **Stile illustrazione** (`imagegen.js`): riportato verso la **caricatura a fumetto ricca e colorata** delle copertine storiche (via il "flat/minimal" precedente, che era la direzione sbagliata). Riferimenti di stile di default aggiornati a 3 copertine reali del repo (`edizione-straordinaria-2627`, `trilogia-del-potere`, `speciale-giro-di-boa`).
- **Nuovo `POST /api/gazzetta/rigenera-copertina`**: stessa autenticazione (`GAZZETTA_PUBLISH_SECRET`), lato server fa ripartire la Action `gazzetta-cover.yml` via `workflow_dispatch` con `slug` + **seed nuovo** + `force`, usando `GAZZETTA_GH_TOKEN` (già su Vercel). L'immagine continua a generarla la Action → nessuna chiave immagine su Vercel, nessun accesso GitHub diretto per Hermes. Se il token non può avviare le Action → `403` con istruzioni chiare.
- **Playbook Hermes**: doppia conferma esplicita — **testo prima di pubblicare**, **immagine dopo** (con loop di rigenerazione); il messaggio WhatsApp parte solo dopo l'OK su entrambi. Regole di voce: mai "Euro"/`€` nei premi (usa 🍆), niente superlativi ("epico/mostruoso") se non veri, meno riferimenti al lago nel testo. L'`image_prompt` deve usare i **nomi veri delle squadre** da `/api/verdetto`.

Nessuna modifica a `template.html`, `genera_gazzetta.js`, `publish`/`stato`. Firma di `generateHero()` invariata.

## Test plan
- [x] `node --check` su `imagegen.js`; `loadStyleRefs()` carica le 3 copertine; `STYLE_SUFFIX` orientato a "richly detailed comic"
- [x] `tsc` filtrato sul nuovo route: nessun errore di logica oltre al rumore da dipendenze non installate in sandbox
- [x] Nessun secret nel diff
- [ ] Verifica reale: prossima gazzetta con la doppia conferma; rigenerazione via endpoint (richiede che `GAZZETTA_GH_TOKEN` possa avviare le Action — token classic `repo` già lo fa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hzpc5HYbx21adNFVR91GPy)_