### PR TITLE
Corregge scena troppo spoglia nella copertina (composizione affollata di gag)

### DIFF
--- a/docs/HERMES_PLAYBOOK.md
+++ b/docs/HERMES_PLAYBOOK.md
@@ -90,8 +90,13 @@ podio, cucchiaio di legno…), mai nomi inventati: così la caricatura ritrae le
 giuste della giornata (es. il campione sul trono è la squadra reale, il cucchiaio di legno
 ha il mestolo, ecc.). Puoi attingere ai **motivi ricorrenti** della testata: il cucciolo
 "Cuccioloni", il razzo "Stoke Azzo", il lupo, la pioggia di melanzane 🍆, il trono, il lago
-di Como con barca a remi, l'auto d'epoca "Brianza". Un solo soggetto focale chiaro. Niente
-testo leggibile nell'immagine (le scritte le mette il template).
+di Como con barca a remi, l'auto d'epoca "Brianza".
+
+**La scena deve essere affollata di gag, non un soggetto isolato**: descrivi un'azione
+centrale (l'eroe/il campione di giornata) MA circondata da 2-3 elementi comici di contorno
+(comparse che reagiscono, una mascotte, un oggetto/gag legato alla giornata) — guarda le
+copertine storiche come riferimento di densità, non stanno mai su un solo personaggio in
+uno spazio vuoto. Niente testo leggibile nell'immagine (le scritte le mette il template).
 
 ### 3b. Conferma del TESTO (obbligatoria)
 

--- a/scripts/gazzetta/lib/imagegen.js
+++ b/scripts/gazzetta/lib/imagegen.js
@@ -65,11 +65,16 @@ const STYLE_SUFFIX =
     'Detailed full-color comic caricature illustration for the front page of a satirical ' +
     'fantasy-football newspaper. Richly detailed hand-drawn editorial cartoon like classic ' +
     'satirical sports comics: bold clean ink outlines, saturated full colors with shading and ' +
-    'highlights, exaggerated caricatured characters and mascots with big expressions, lively and ' +
-    'busy but readable composition. Setting: Lake Como (Lario) with mountains, a rowing boat and ' +
-    'lakeside villages in the background. Goliardic playful humor, never mean-spirited. ' +
-    'This is a DRAWN COLORED COMIC - NOT flat or minimalist, NOT painterly-realistic, NOT a 3D render. ' +
-    'Clear focal subject. Loose free edges suitable for cropping. ' +
+    'highlights, exaggerated caricatured characters and mascots with big expressions. ' +
+    'The scene must be BUSY and PACKED, not sparse or minimal: one clear hero action in the ' +
+    'foreground, PLUS several extra comic elements scattered around it - side characters or ' +
+    'onlookers reacting, a recurring mascot animal, small sight-gag props and objects relevant ' +
+    'to the story, background details. Think crowded satirical-magazine cover, many things to look ' +
+    'at, not a single figure alone in empty space. Setting: Lake Como (Lario) with mountains, a ' +
+    'rowing boat and lakeside villages worked into the background. Goliardic playful humor, never ' +
+    'mean-spirited. This is a DRAWN COLORED COMIC - NOT flat or minimalist, NOT painterly-realistic, ' +
+    'NOT a 3D render, NOT a single isolated subject on an empty background. ' +
+    'Loose free edges suitable for cropping. ' +
     'NO readable text, letters, numbers, watermark, signature or logo of any kind.';
 
 // Istruzione testuale che accompagna i riferimenti di stile (solo google/openrouter)
@@ -77,9 +82,10 @@ const STYLE_REF_INSTRUCTION =
     'The attached images are past covers of "La Gazzetta del Laghèe", a satirical fantasy-football ' +
     'newspaper. Match their style very closely: the same richly detailed, full-color hand-drawn ' +
     'comic caricature look, bold ink outlines, saturated colors with shading, exaggerated character ' +
-    'faces, recurring mascots and lively busy composition. Keep it a drawn colored comic (not a ' +
-    'painting, not a photo, not a 3D render). Do NOT copy their exact subject or layout: the scene ' +
-    'comes only from the prompt below.';
+    'faces, recurring mascots, and above all the same BUSY, PACKED composition with several comic ' +
+    'elements sharing the frame - notice how none of these reference covers show just one isolated ' +
+    'figure in empty space. Keep it a drawn colored comic (not a painting, not a photo, not a 3D ' +
+    'render). Do NOT copy their exact subject or layout: the scene comes only from the prompt below.';
 
 const MIME_BY_EXT = { '.webp': 'image/webp', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg' };
 


### PR DESCRIPTION
## Summary
Osservato sul secondo test reale (giornata 38, stagione 2526): la copertina generata con lo stile "richly detailed comic" di #78 usava già il codice giusto (verificato via timestamp — non un problema di deploy), ma restituiva una scena con **un solo personaggio isolato** su sfondo pulito, molto più spoglia delle 4 copertine storiche di riferimento (affollate di gag: cucciolo, razzo, lupo, cartelli, melanzane...).

Causa: `STYLE_SUFFIX` chiedeva contemporaneamente *"lively busy composition"* **e** *"single clear focal subject, uncluttered background"* — istruzioni in contraddizione, e il modello ha risolto scegliendo la versione più spoglia.

Fix:
- `imagegen.js`: tolta l'ambiguità, il suffisso ora chiede esplicitamente una scena **affollata** (azione centrale + 2-3 elementi comici di contorno), esplicitando che NON deve essere "a single isolated figure in empty space".
- `HERMES_PLAYBOOK.md`: stessa indicazione per l'`image_prompt` che scrive Hermes.

Nessuna modifica a risoluzione/provider/riferimenti di stile (già a posto da #78).

## Test plan
- [x] `node --check` su `imagegen.js`
- [x] Verificato che `STYLE_SUFFIX` contiene la nuova istruzione "BUSY and PACKED"
- [ ] Verifica reale al prossimo test: la scena dovrebbe avere più elementi di contorno, non un solo soggetto isolato

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hzpc5HYbx21adNFVR91GPy)_