### PR TITLE
Stop applicati dal server e gag sui nomi squadra nell'illustrazione

### DIFF
--- a/app/api/gazzetta/publish/route.ts
+++ b/app/api/gazzetta/publish/route.ts
@@ -88,6 +88,10 @@ function valida(payload: any): string[] {
         errori.push('force: se presente deve essere booleano');
     }
 
+    if (payload?.conferma !== undefined && typeof payload.conferma !== 'boolean') {
+        errori.push('conferma: se presente deve essere booleano');
+    }
+
     return errori;
 }
 
@@ -344,6 +348,23 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(
             { ok: false, error: 'Payload non valido: correggi i campi indicati e riprova.', dettagli: errori },
             { status: 400 }
+        );
+    }
+
+    // Presidio contro la pubblicazione senza l'OK dell'utente: senza `conferma: true`
+    // non si pubblica. Il server non può verificare davvero che un umano abbia detto sì
+    // (la garanzia vera sta nel playbook), ma così un agente che salta il passaggio
+    // riceve un errore esplicito invece di mandare online l'articolo.
+    if (payload.conferma !== true) {
+        return NextResponse.json(
+            {
+                ok: false,
+                error: 'Pubblicazione non confermata. Mostra prima la bozza all\'utente e chiedi il suo OK esplicito; '
+                    + 'solo dopo che l\'utente ha risposto di sì, ripeti questa chiamata aggiungendo "conferma": true. '
+                    + 'Non aggiungere "conferma": true di tua iniziativa.',
+                richiedeConferma: true,
+            },
+            { status: 409 }
         );
     }
 

--- a/docs/AUTOMAZIONE_GAZZETTA.md
+++ b/docs/AUTOMAZIONE_GAZZETTA.md
@@ -5,6 +5,30 @@
 > le sessioni di Claude Code non condividono memoria tra loro. Leggi prima questo file,
 > poi continua da qui.
 
+## ➕ Aggiunta (30 luglio 2026, 2) — stop applicati dal server e gag sui nomi squadra
+
+Dai test reali sono emersi due problemi, entrambi corretti qui.
+
+**Hermes pubblicava senza aspettare l'OK.** Mostrava la bozza ma proseguiva nello stesso
+turno. Il playbook ora ha una sezione "Regola dei due STOP" in testa e stop espliciti ai
+passi 3b (testo) e 5 (immagine), con l'istruzione di chiudere il turno. In più c'è un
+presidio lato server: `POST /api/gazzetta/publish` **richiede `"conferma": true`**,
+altrimenti risponde `409 richiedeConferma`. Il server non può verificare davvero che un
+umano abbia detto sì — la garanzia sta nel prompt — ma un agente che salta il passaggio
+ora riceve un errore invece di mandare online l'articolo.
+
+**L'illustrazione usciva in stile "vignetta retrò da settimana enigmistica"**, con soggetti
+poco riconoscibili. Il suffisso di stile in `imagegen.js` è stato riscritto verso il
+**fumetto moderno pulito**: colori vivaci, tratto netto, e soprattutto una clausola
+`CLARITY IS ESSENTIAL` (ogni soggetto dev'essere riconoscibile a colpo d'occhio) più una
+lista esplicita di cose da evitare (texture di stampa vintage, retini, xilografia, palette
+slavata, tratto sporco). Nel playbook è stato aggiunto un **glossario visivo dei nomi
+squadra**: il criterio è trasformare il nome in un soggetto disegnabile (Cuccioloni → un
+cucciolo, Raga di Oporto → Porto/vino, Stratosvarius → una papera clamorosa…), così la
+copertina racconta le squadre vere invece di manager generici.
+
+---
+
 ## ➕ Aggiunta (30 luglio 2026) — conferma testo+immagine e rigenerazione copertina
 
 Su richiesta: Hermes non pubblica più "di slancio". Ora il flusso ha **due conferme**

--- a/docs/HERMES_PLAYBOOK.md
+++ b/docs/HERMES_PLAYBOOK.md
@@ -27,6 +27,23 @@ Ruoli:
 
 ---
 
+## ⛔ Regola dei due STOP (la più importante di tutte)
+
+La procedura ha **due punti in cui devi fermarti e aspettare una risposta dell'utente**:
+
+1. **Passo 3b** — conferma del **testo**, prima di pubblicare.
+2. **Passo 5** — conferma dell'**immagine**, prima di consegnare il messaggio WhatsApp.
+
+In entrambi: manda il messaggio, **chiudi il turno, non chiamare altri strumenti**. Non
+proseguire perché "tanto poi glielo faccio vedere": una volta pubblicato è online.
+Non decidere tu al posto dell'utente. **Il silenzio non è un sì**, e nemmeno un "bello!"
+generico è una conferma se non è riferito a quella domanda.
+
+Se l'utente ti chiede di fare tutto in autonomia, spiega che le due conferme sono
+volute e chiedi comunque.
+
+---
+
 ## Procedura completa (in ordine)
 
 ### 1. Che giornata è
@@ -85,29 +102,70 @@ Produci internamente: `title`, `description`, `body_md`, `cover.titolo_principal
 `cover.sottotitolo` e `cover.image_prompt` (in inglese, descrive solo la scena: lo stile
 della testata lo aggiunge automaticamente il generatore di immagini).
 
-**L'`image_prompt` usa i nomi VERI delle squadre presi da `/api/verdetto`** (campione,
-podio, cucchiaio di legno…), mai nomi inventati: così la caricatura ritrae le squadre
-giuste della giornata (es. il campione sul trono è la squadra reale, il cucchiaio di legno
-ha il mestolo, ecc.). Puoi attingere ai **motivi ricorrenti** della testata: il cucciolo
-"Cuccioloni", il razzo "Stoke Azzo", il lupo, la pioggia di melanzane 🍆, il trono, il lago
-di Como con barca a remi, l'auto d'epoca "Brianza".
+#### Come si scrive l'`image_prompt` — la regola del gioco di parole
 
-**La scena deve essere affollata di gag, non un soggetto isolato**: descrivi un'azione
-centrale (l'eroe/il campione di giornata) MA circondata da 2-3 elementi comici di contorno
-(comparse che reagiscono, una mascotte, un oggetto/gag legato alla giornata) — guarda le
-copertine storiche come riferimento di densità, non stanno mai su un solo personaggio in
-uno spazio vuoto. Niente testo leggibile nell'immagine (le scritte le mette il template).
+**Il cuore della copertina sono i nomi delle squadre trasformati in personaggi visivi.**
+Prendi i nomi VERI da `/api/verdetto` (campione di giornata, podio, cucchiaio di legno) e
+per ognuno inventa un **soggetto disegnabile che gioca sul nome**. Mai nomi inventati, mai
+un manager generico senza identità.
 
-### 3b. Conferma del TESTO (obbligatoria)
+Glossario visivo delle squadre ricorrenti (usa questo, ed estendilo con lo stesso criterio
+per le squadre che non sono in elenco):
+
+| Squadra | Soggetto da disegnare |
+|---|---|
+| Cuccioloni | un cucciolo di golden retriever con bandana, disegnato bene |
+| Raga di Oporto | ragazzi festanti col vino Porto / caravelle e case colorate di Porto |
+| Stoke Azzo | un razzo che decolla, o una melanzana 🍆 gigante (allusione, mai volgarità esplicita) |
+| Brianza Boys | un gruppetto di ragazzi in tuta con lo striscione "Brianza" |
+| Stratosvarius | un tizio che fa una papera clamorosa, con stelline di svarione intorno |
+| Caniggia Vola | un giocatore coi capelloni anni '90 che vola a mezz'aria |
+| Fantagiulia | una figura femminile alata sopra la scena |
+| AS Tronzi | un tronco / ceppo di legno con la faccia |
+| Cippalippa1418 | un gesto di scherno alla vecchia maniera |
+| Fantamagica | un mago con cilindro e bacchetta |
+
+Criterio per una squadra nuova: leggi il nome, trova la parola concreta dentro il nome
+(animale, città, oggetto, verbo) e disegna quella. Se il nome non suggerisce niente, dai
+alla squadra una maglia con un colore distintivo e un tratto caratteriale.
+
+**Il ruolo lo decide la giornata**: il campione sta al centro in trionfo, il cucchiaio di
+legno è mesto in un angolo col mestolo, gli altri del podio reagiscono intorno.
+
+**La scena deve essere affollata di gag, non un soggetto isolato**: un'azione centrale
+(il campione di giornata) circondata da 2-3 elementi comici di contorno — le altre squadre
+come personaggi, una mascotte, un oggetto-gag legato alla giornata, il lago sullo sfondo.
+Le copertine storiche non mostrano mai un solo personaggio in uno spazio vuoto.
+
+**Descrivi ogni soggetto in modo concreto e disegnabile** (cosa è, cosa fa, com'è vestito):
+serve a farlo uscire nitido e riconoscibile, non una macchia informe. Lo stile grafico
+(fumetto moderno, colori vivaci, tratto pulito) lo aggiunge in automatico il generatore:
+tu descrivi solo **chi c'è e cosa fa**.
+
+Niente testo leggibile nell'immagine: le scritte le mette il template, e i modelli le
+disegnano storte. Se serve evocare una scritta, usa un cartello **vuoto** o un simbolo.
+
+### 3b. Conferma del TESTO (STOP OBBLIGATORIO)
+
+⛔ **Questo è uno stop vero: manda il messaggio e CHIUDI IL TURNO.** Non chiamare nessun
+altro strumento, non pubblicare, non proseguire "tanto poi glielo mostro". Devi aspettare
+un nuovo messaggio dell'utente.
 
 Manda all'utente su Telegram il **testo** della bozza (title + description + body_md +
-image_prompt) e chiedi esplicitamente: **«Pubblico così? Vuoi modificare qualcosa (dimmi
-cosa)? O rifaccio?»**
-- Se risponde **OK / vai / 👍** → vai al passo 4.
-- Se manda **correzioni** → riscrivi applicandole e rimanda la bozza.
+image_prompt) e chiudi con:
+
+```
+Confermi il TESTO?
+✅ "ok testo" → procedo con la pubblicazione
+✏️ dimmi cosa cambiare → riscrivo
+🔄 "rifai" → rigenero da capo
+```
+
+- Se risponde **ok / vai / 👍** → vai al passo 4.
+- Se manda **correzioni** → riscrivi e rimanda la bozza (di nuovo con lo stop).
 - Se dice di rifare → rigenera da capo.
 
-**NON procedere alla pubblicazione senza un OK esplicito dell'utente sul testo.**
+**Il silenzio non è un sì.** Senza una risposta esplicita dell'utente non si pubblica.
 
 ### 4. Pubblica
 
@@ -124,29 +182,44 @@ Content-Type: application/json
     "titolo_principale": "MAIUSCOLO, MAX 60 CARATTERI",
     "sottotitolo": "Sommario della giornata, max 180 caratteri",
     "image_prompt": "Detailed English prompt for the satirical hero illustration"
-  }
+  },
+  "conferma": true
 }
 ```
+
+`"conferma": true` va messo **solo dopo che l'utente ha detto sì al passo 3b**. Senza,
+il server risponde `409` e non pubblica: è la rete di sicurezza contro la pubblicazione
+non autorizzata. Non aggiungerlo mai di tua iniziativa per "sbloccare" la chiamata.
 
 Non includere `box1`/`box2`/`box3`, `giornata` o `stagione`: il server li ricava da solo
 (li puoi passare solo se stai deliberatamente forzando una giornata specifica, caso raro).
 
 Risposte:
 - **`201`** → pubblicato. Contiene `slug`, `commit`, `liveUrl`, `coverUrl`. Vai al passo 5.
+- **`409` con `richiedeConferma: true`** → hai saltato la conferma dell'utente. Torna al
+  passo 3b, mostra la bozza e aspetta la risposta.
 - **`400`** → `dettagli` elenca ogni campo da correggere. Correggi e ripeti la chiamata.
 - **`409`** → l'articolo esiste già o la giornata non è pronta. Riporta `error` all'utente
   e fermati (non ripetere con `force` senza che l'utente lo chieda esplicitamente).
 - **`401`/`500`** → problema di configurazione lato server. Riporta l'errore e fermati.
 
-### 5. Conferma dell'IMMAGINE (obbligatoria)
+### 5. Conferma dell'IMMAGINE (STOP OBBLIGATORIO)
 
 Attendi ~90 secondi (tempo di run della GitHub Action che genera la copertina), poi
 controlla che `coverUrl` risponda 200 (**max 4 tentativi, un minuto di distanza l'uno
 dall'altro**). Se dopo i tentativi non risponde ancora, avvisa l'utente che la Action
 potrebbe essere fallita (da controllare nella tab Actions di GitHub) e fermati.
 
-Quando la copertina è pronta, **mandala su Telegram** e chiedi: **«Ti va bene questa
-copertina, o ne rigenero un'altra variante?»**
+⛔ **Secondo stop vero.** Quando la copertina è pronta, **mandala su Telegram come
+immagine** e chiudi con:
+
+```
+Confermi l'IMMAGINE?
+✅ "ok immagine" → ti preparo il messaggio per WhatsApp
+🔄 "rigenera" → ne creo un'altra variante
+```
+
+Poi **chiudi il turno e aspetta la risposta.** Non mandare il messaggio WhatsApp adesso.
 
 - Se l'utente **approva** → vai al passo 6.
 - Se l'utente **vuole una variante** (o dice che l'immagine non va) → chiama:

--- a/scripts/gazzetta/lib/imagegen.js
+++ b/scripts/gazzetta/lib/imagegen.js
@@ -59,33 +59,39 @@ const OPENROUTER_RESOLUTION = process.env.OPENROUTER_RESOLUTION || '2K';
 
 // Suffisso di stile per mantenere coerenza grafica con le vecchie copertine.
 // Descrive la testata (non la scena, che la scrive Hermes nel prompt).
-// Le copertine storiche sono caricature a fumetto RICCHE, dettagliate e super colorate
-// (non minimal/piatte): il suffisso spinge esattamente in quella direzione.
+// Obiettivo: fumetto MODERNO, pulito e leggibile - ogni personaggio e oggetto si deve
+// riconoscere a colpo d'occhio. Da evitare come la peste il look "vignetta retrò da
+// settimanale enigmistico" (texture di stampa vintage, retini, xilografia, colori spenti),
+// che è quello che il modello produceva prima.
 const STYLE_SUFFIX =
-    'Detailed full-color comic caricature illustration for the front page of a satirical ' +
-    'fantasy-football newspaper. Richly detailed hand-drawn editorial cartoon like classic ' +
-    'satirical sports comics: bold clean ink outlines, saturated full colors with shading and ' +
-    'highlights, exaggerated caricatured characters and mascots with big expressions. ' +
-    'The scene must be BUSY and PACKED, not sparse or minimal: one clear hero action in the ' +
-    'foreground, PLUS several extra comic elements scattered around it - side characters or ' +
-    'onlookers reacting, a recurring mascot animal, small sight-gag props and objects relevant ' +
-    'to the story, background details. Think crowded satirical-magazine cover, many things to look ' +
-    'at, not a single figure alone in empty space. Setting: Lake Como (Lario) with mountains, a ' +
-    'rowing boat and lakeside villages worked into the background. Goliardic playful humor, never ' +
-    'mean-spirited. This is a DRAWN COLORED COMIC - NOT flat or minimalist, NOT painterly-realistic, ' +
-    'NOT a 3D render, NOT a single isolated subject on an empty background. ' +
+    'Modern polished full-color comic illustration for the front page of a satirical ' +
+    'fantasy-football newspaper. Contemporary digital cartoon art with crisp clean ink outlines, ' +
+    'bright saturated colors, smooth cel shading and highlights, expressive caricatured characters ' +
+    'and mascots with big readable faces. ' +
+    'CLARITY IS ESSENTIAL: every character, animal, object and prop must be drawn cleanly and be ' +
+    'instantly recognizable for what it is - solid well-defined shapes, correct anatomy and ' +
+    'proportions, no vague blobs, no mushy or scribbly details, no ambiguous shapes. ' +
+    'The scene must be BUSY and PACKED, not sparse: one clear hero action in the foreground, PLUS ' +
+    'several extra comic elements around it - side characters reacting, mascot animals, sight-gag ' +
+    'props relevant to the story. Many things to look at, but each one crisply drawn. ' +
+    'Setting: Lake Como (Lario) with mountains, a rowing boat and lakeside villages in the background. ' +
+    'Irreverent, cheeky, fun modern humor - never mean-spirited, never dated. ' +
+    'ABSOLUTELY AVOID: vintage or retro print look, old newspaper cartoon style, halftone dot ' +
+    'texture, woodcut / engraving / linocut / risograph, aged paper texture, muted washed-out ' +
+    'palette, sketchy scratchy linework, painterly realism, photorealism, 3D render, ' +
+    'single isolated subject on an empty background. ' +
     'Loose free edges suitable for cropping. ' +
     'NO readable text, letters, numbers, watermark, signature or logo of any kind.';
 
 // Istruzione testuale che accompagna i riferimenti di stile (solo google/openrouter)
 const STYLE_REF_INSTRUCTION =
     'The attached images are past covers of "La Gazzetta del Laghèe", a satirical fantasy-football ' +
-    'newspaper. Match their style very closely: the same richly detailed, full-color hand-drawn ' +
-    'comic caricature look, bold ink outlines, saturated colors with shading, exaggerated character ' +
-    'faces, recurring mascots, and above all the same BUSY, PACKED composition with several comic ' +
-    'elements sharing the frame - notice how none of these reference covers show just one isolated ' +
-    'figure in empty space. Keep it a drawn colored comic (not a painting, not a photo, not a 3D ' +
-    'render). Do NOT copy their exact subject or layout: the scene comes only from the prompt below.';
+    'newspaper. Match their style very closely: the same modern, clean, brightly colored comic ' +
+    'illustration look, crisp ink outlines, expressive caricatured faces, recurring mascots, and ' +
+    'the same BUSY composition with several elements sharing the frame. Note especially how every ' +
+    'single element in them is drawn clearly and is immediately recognizable, and how bright and ' +
+    'contemporary the colors are - not faded, not retro-print, not a vintage newspaper cartoon. ' +
+    'Do NOT copy their exact subject or layout: the scene comes only from the prompt below.';
 
 const MIME_BY_EXT = { '.webp': 'image/webp', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg' };
 


### PR DESCRIPTION
## Summary
Due problemi emersi dal test reale sulla giornata 38.

**1. Hermes pubblicava senza aspettare l'OK** (mostrava la bozza ma proseguiva nello stesso turno).
- `HERMES_PLAYBOOK.md`: nuova sezione **"Regola dei due STOP"** in testa, e stop espliciti ai passi 3b (testo) e 5 (immagine) con l'istruzione di *chiudere il turno* e i box di conferma da mostrare all'utente.
- `publish/route.ts`: presidio lato server — la pubblicazione ora **richiede `"conferma": true`**, altrimenti risponde `409` con `richiedeConferma: true` e un messaggio che dice di chiedere prima all'utente. Il server non può verificare davvero che un umano abbia acconsentito (la garanzia sta nel prompt), ma un agente che salta il passaggio ora riceve un errore invece di mandare online l'articolo. Fail-closed, e il check avviene prima di qualsiasi effetto collaterale.

**2. L'illustrazione usciva in stile "vignetta retrò da settimana enigmistica"**, con soggetti poco riconoscibili.
- `imagegen.js`: `STYLE_SUFFIX` riscritto verso il **fumetto moderno pulito** (colori vivaci, tratto netto, cel shading), con clausola `CLARITY IS ESSENTIAL` — ogni soggetto dev'essere riconoscibile a colpo d'occhio — e lista esplicita di cose da evitare: texture di stampa vintage, retini/halftone, xilografia/incisione, palette slavata, tratto sporco. Rimosso `"classic satirical sports comics"`, che era la principale spinta verso il retrò.
- `HERMES_PLAYBOOK.md`: **glossario visivo dei nomi squadra** — il criterio è trasformare il nome in un soggetto disegnabile (Cuccioloni → un cucciolo, Raga di Oporto → Porto/vino, Stratosvarius → una papera clamorosa…), più il metodo per estenderlo alle squadre nuove, così la copertina racconta le squadre vere invece di manager generici.

Nessuna nuova dipendenza. Nessuna modifica a `template.html` / `genera_gazzetta.js`.

## Test plan
- [x] `node --check` su `imagegen.js`; `tsc` filtrato su `publish/route.ts` senza errori di logica
- [x] Verificato che `STYLE_SUFFIX` contiene `CLARITY IS ESSENTIAL` e la lista anti-retro; 3 riferimenti di stile caricati
- [x] Nessun secret nel diff
- [ ] Verifica reale: publish senza `conferma` → `409`; con `conferma: true` → `201`; copertina con soggetti riconoscibili e gag sui nomi squadra

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hzpc5HYbx21adNFVR91GPy)_