### PR TITLE
Evita il giornale dentro il giornale e la scena affollata a caso

### DIFF
--- a/docs/HERMES_PLAYBOOK.md
+++ b/docs/HERMES_PLAYBOOK.md
@@ -137,15 +137,25 @@ alla squadra una maglia con un colore distintivo e un tratto caratteriale.
 **Il ruolo lo decide la giornata**: il campione sta al centro in trionfo, il cucchiaio di
 legno è mesto in un angolo col mestolo, gli altri del podio reagiscono intorno.
 
-**La scena deve essere affollata di gag, non un soggetto isolato**: un'azione centrale
-(il campione di giornata) circondata da 2-3 elementi comici di contorno — le altre squadre
-come personaggi, una mascotte, un oggetto-gag legato alla giornata, il lago sullo sfondo.
-Le copertine storiche non mostrano mai un solo personaggio in uno spazio vuoto.
+**Massimo 3-4 soggetti, e ognuno deve avere un motivo per essere lì.** Ogni personaggio
+corrisponde a una squadra che ha fatto qualcosa in QUELLA giornata:
+
+- il **campione di giornata** al centro, in trionfo;
+- il **cucchiaio di legno** mesto in un angolo col mestolo;
+- **una o due squadre del podio** che reagiscono.
+
+Niente comparse decorative, niente folla, niente gag prese dal glossario se quella squadra
+non c'entra con la giornata. Una scena pulita con 3-4 soggetti che significano qualcosa vale
+molto più di una affollata di roba a caso: è l'errore da evitare.
 
 **Descrivi ogni soggetto in modo concreto e disegnabile** (cosa è, cosa fa, com'è vestito):
 serve a farlo uscire nitido e riconoscibile, non una macchia informe. Lo stile grafico
 (fumetto moderno, colori vivaci, tratto pulito) lo aggiunge in automatico il generatore:
 tu descrivi solo **chi c'è e cosa fa**.
+
+**Descrivi solo l'illustrazione, mai la pagina.** L'immagine finisce dentro un template che
+ha già testata, titolo e box dati: non chiedere mai testate, titoli, cornici, riquadri o
+impaginazioni dentro l'immagine, altrimenti esce un giornale dentro il giornale.
 
 Niente testo leggibile nell'immagine: le scritte le mette il template, e i modelli le
 disegnano storte. Se serve evocare una scritta, usa un cartello **vuoto** o un simbolo.

--- a/scripts/gazzetta/lib/imagegen.js
+++ b/scripts/gazzetta/lib/imagegen.js
@@ -84,27 +84,39 @@ const STYLE_SUFFIX =
     'CLARITY IS ESSENTIAL: every character, animal, object and prop must be drawn cleanly and be ' +
     'instantly recognizable for what it is - solid well-defined shapes, correct anatomy and ' +
     'proportions, no vague blobs, no mushy or scribbly details, no ambiguous shapes. ' +
-    'The scene must be BUSY and PACKED, not sparse: one clear hero action in the foreground, PLUS ' +
-    'several extra comic elements around it - side characters reacting, mascot animals, sight-gag ' +
-    'props relevant to the story. Many things to look at, but each one crisply drawn. ' +
+    'The scene is populated but PURPOSEFUL: one clear hero action in the foreground plus only the ' +
+    'few supporting characters and props named in the scene description - every element must mean ' +
+    'something. Do not pad the picture with extra random characters, crowds or props that were not ' +
+    'asked for. Better a clean scene with 3-4 meaningful subjects than a cluttered one. ' +
     'Setting: Lake Como (Lario) with mountains, a rowing boat and lakeside villages in the background. ' +
     'Irreverent, cheeky, fun modern humor - never mean-spirited, never dated. ' +
-    'ABSOLUTELY AVOID: vintage or retro print look, old newspaper cartoon style, halftone dot ' +
-    'texture, woodcut / engraving / linocut / risograph, aged paper texture, muted washed-out ' +
-    'palette, sketchy scratchy linework, painterly realism, photorealism, 3D render, ' +
-    'single isolated subject on an empty background. ' +
+    '' +
+    'OUTPUT THE ARTWORK ONLY. This image is placed inside an existing newspaper layout that already ' +
+    'has its own masthead, headline and data boxes, so the picture itself must be JUST the ' +
+    'illustration, edge to edge, like a single painting. Do NOT draw a newspaper or magazine page. ' +
+    'Do NOT draw a masthead, logo, title bar, headline strip, caption, byline, page border, frame, ' +
+    'margins, columns, or small thumbnail panels/boxes along any edge. Nothing that looks like page ' +
+    'furniture. ' +
+    '' +
+    'ABSOLUTELY AVOID: any newspaper/magazine page layout inside the image, vintage or retro print ' +
+    'look, old newspaper cartoon style, halftone dot texture, woodcut / engraving / linocut / ' +
+    'risograph, aged paper texture, muted washed-out palette, sketchy scratchy linework, painterly ' +
+    'realism, photorealism, 3D render, single isolated subject on an empty background. ' +
     'Loose free edges suitable for cropping. ' +
     'NO readable text, letters, numbers, watermark, signature or logo of any kind.';
 
 // Istruzione testuale che accompagna i riferimenti di stile (solo google/openrouter)
 const STYLE_REF_INSTRUCTION =
-    'The attached images are past covers of "La Gazzetta del Laghèe", a satirical fantasy-football ' +
-    'newspaper. Match their style very closely: the same modern, clean, brightly colored comic ' +
-    'illustration look, crisp ink outlines, expressive caricatured faces, recurring mascots, and ' +
-    'the same BUSY composition with several elements sharing the frame. Note especially how every ' +
-    'single element in them is drawn clearly and is immediately recognizable, and how bright and ' +
-    'contemporary the colors are - not faded, not retro-print, not a vintage newspaper cartoon. ' +
-    'Do NOT copy their exact subject or layout: the scene comes only from the prompt below.';
+    'The attached images are past FRONT PAGES of "La Gazzetta del Laghèe", a satirical ' +
+    'fantasy-football newspaper. Look ONLY at the big central illustration inside them and copy its ' +
+    'DRAWING STYLE: modern clean brightly-colored comic art, crisp ink outlines, expressive ' +
+    'caricatured faces, recurring mascots, every element clearly drawn and instantly recognizable, ' +
+    'bright contemporary colors (not faded, not retro-print). ' +
+    'CRITICAL: these references are full newspaper pages, but you must NOT reproduce the page ' +
+    'itself. Ignore completely their masthead/logo, their headline text, their coloured caption ' +
+    'bars and the row of small panels at the bottom. Your output must be ONLY the central ' +
+    'illustration artwork, filling the whole frame, with no page layout around it. ' +
+    'Do NOT copy their subject or composition either: the scene comes only from the prompt below.';
 
 const MIME_BY_EXT = { '.webp': 'image/webp', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg' };
 


### PR DESCRIPTION
## Summary
Due difetti visibili nell'ultima copertina generata (giornata 38, ora davvero via Gemini con i riferimenti di stile — qualità molto migliore).

**1. Giornale dentro il giornale.** L'illustrazione conteneva una propria testata "La Gazzetta del Laghèe", un proprio titolo e la fila di riquadri in basso (REPORT CARD / L'EDITORIALE / MATCH RECAP), duplicando il template che la contiene. Causa: i riferimenti di stile sono **copertine intere**, quindi il modello ne copiava fedelmente anche l'impaginazione, non solo il tratto.
- `STYLE_REF_INSTRUCTION`: ora dice esplicitamente di guardare **solo l'illustrazione centrale** dei riferimenti e di ignorarne masthead, titoli, barre-didascalia e pannelli in basso.
- `STYLE_SUFFIX`: nuova clausola `OUTPUT THE ARTWORK ONLY` (niente pagina, testata, cornici, margini, colonne, thumbnail lungo i bordi) più il divieto ripetuto nella lista dei negativi.

**2. Scena affollata di elementi irrilevanti.** C'erano personaggi che non c'entravano con la giornata (comparse con maglia di Oporto, soggetti non collegati ai risultati). La spinta precedente a `BUSY and PACKED` — che avevo introdotto per correggere una scena troppo spoglia — aveva superato il bersaglio.
- Ribilanciato in "popolata ma **mirata**": ogni elemento deve significare qualcosa, meglio 3-4 soggetti sensati che una scena piena di roba a caso.
- `HERMES_PLAYBOOK.md`: max 3-4 soggetti, ognuno corrispondente a una squadra che ha fatto qualcosa **in quella giornata** (campione al centro, cucchiaio di legno con mestolo, una o due del podio); mai chiedere impaginazioni dentro l'immagine.

Nessuna modifica a `template.html` / `genera_gazzetta.js`. Dimensioni verificate: copertina finale 1800×2322 px (2× del template 900×1161), corretta.

## Test plan
- [x] `node --check` OK
- [x] Verificato che `STYLE_SUFFIX` contiene `OUTPUT THE ARTWORK ONLY`, il divieto sui pannelli e la clausola `PURPOSEFUL`; 3 riferimenti caricati
- [x] Nessun secret nel diff
- [ ] Verifica reale: la prossima copertina non deve contenere testata/titolo/riquadri propri, e i soggetti devono essere solo quelli legati ai risultati della giornata

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hzpc5HYbx21adNFVR91GPy)_