### PR TITLE
feat(gazzetta): preview draft before go-live

### DIFF
--- a/app/api/articles/[id]/route.ts
+++ b/app/api/articles/[id]/route.ts
@@ -22,6 +22,11 @@ export async function GET(
         const fileContent = fs.readFileSync(filePath, 'utf8');
         const { data, content } = matter(fileContent);
 
+        // Bozza non leggibile via URL diretto finché non è pubblicata
+        if (data.draft === true) {
+            return NextResponse.json({ error: 'Scritto non trovato' }, { status: 404 });
+        }
+
         return NextResponse.json({
             metadata: {
                 title: data.title || id,

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -14,6 +14,9 @@ export async function GET() {
             const fileContent = fs.readFileSync(filePath, 'utf8');
             const { data } = matter(fileContent);
 
+            // Bozze Hermes (preview copertina): non in elenco pubblico
+            if (data.draft === true) return null;
+
             const date = data.date || "Senza Data";
             const stagione = data.stagione || (
                 new Date(date) >= new Date(NEW_SEASON_ARTICLES_FROM) ? CURRENT_SEASON : ARCHIVED_SEASON
@@ -29,7 +32,7 @@ export async function GET() {
                 stagione,
                 placeholder: false
             };
-        });
+        }).filter(Boolean);
 
         // Strict chronological sort by date descending (newest first)
         articles.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());

--- a/app/api/gazzetta/publish/route.ts
+++ b/app/api/gazzetta/publish/route.ts
@@ -92,6 +92,10 @@ function valida(payload: any): string[] {
         errori.push('conferma: se presente deve essere booleano');
     }
 
+    if (payload?.preview !== undefined && typeof payload.preview !== 'boolean') {
+        errori.push('preview: se presente deve essere booleano');
+    }
+
     return errori;
 }
 
@@ -211,6 +215,24 @@ async function trovaUltimaGiornataPubblicata(owner: string, repo: string, token:
         }
     }
     return max;
+}
+
+
+/** Legge il frontmatter di un .md su GitHub e dice se è bozza (draft: true). */
+async function isDraftSuGitHub(owner: string, repo: string, repoPath: string, token: string): Promise<boolean> {
+    const res = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/contents/${repoPath}?ref=main`, {
+        headers: ghHeaders(token),
+        cache: 'no-store',
+    });
+    if (res.status === 404) return false;
+    if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`GitHub ha risposto ${res.status} nel leggere ${repoPath}: ${body.slice(0, 200)}`);
+    }
+    const json = await res.json();
+    const raw = Buffer.from(String(json?.content || ''), 'base64').toString('utf8');
+    const { data } = matter(raw);
+    return data?.draft === true;
 }
 
 /**
@@ -351,15 +373,14 @@ export async function POST(request: NextRequest) {
         );
     }
 
-    // Presidio contro la pubblicazione senza l'OK dell'utente: senza `conferma: true`
-    // non si pubblica. Il server non può verificare davvero che un umano abbia detto sì
-    // (la garanzia vera sta nel playbook), ma così un agente che salta il passaggio
-    // riceve un errore esplicito invece di mandare online l'articolo.
+    // Presidio: senza `conferma: true` non si scrive nulla su GitHub (né bozza né live).
+    // preview:true = bozza offline (draft nel frontmatter, non in elenco sito) per generare la copertina.
+    // preview assente/false = go-live vero, solo dopo OK testo + OK immagine.
     if (payload.conferma !== true) {
         return NextResponse.json(
             {
                 ok: false,
-                error: 'Pubblicazione non confermata. Mostra prima la bozza all\'utente e chiedi il suo OK esplicito; '
+                error: 'Operazione non confermata. Mostra prima la bozza all\'utente e chiedi il suo OK esplicito; '
                     + 'solo dopo che l\'utente ha risposto di sì, ripeti questa chiamata aggiungendo "conferma": true. '
                     + 'Non aggiungere "conferma": true di tua iniziativa.',
                 richiedeConferma: true,
@@ -367,6 +388,8 @@ export async function POST(request: NextRequest) {
             { status: 409 }
         );
     }
+
+    const preview = payload.preview === true;
 
     const ghToken = process.env.GAZZETTA_GH_TOKEN;
     if (!ghToken) {
@@ -414,11 +437,27 @@ export async function POST(request: NextRequest) {
             { status: 502 }
         );
     }
-    if (shaEsistente && !force) {
-        return NextResponse.json(
-            { ok: false, error: `L'articolo della giornata ${giornata} (${slug}) esiste già. Passa force:true per sovrascriverlo.` },
-            { status: 409 }
-        );
+    // Idempotenza:
+    // - file live esistente → serve force
+    // - file draft esistente → si può sovrascrivere senza force (promuovere a live o aggiornare bozza)
+    // - go-live su draft esistente → ok senza force
+    let esistenteEDraft = false;
+    if (shaEsistente) {
+        try {
+            esistenteEDraft = await isDraftSuGitHub(owner, repo, repoPath, ghToken);
+        } catch (e: any) {
+            return NextResponse.json(
+                { ok: false, error: `Impossibile leggere se l'articolo esistente è bozza: ${e.message}` },
+                { status: 502 }
+            );
+        }
+        const puoSovrascrivereSenzaForce = esistenteEDraft; // bozza sempre updatable/promuovibile
+        if (!force && !puoSovrascrivereSenzaForce) {
+            return NextResponse.json(
+                { ok: false, error: `L'articolo della giornata ${giornata} (${slug}) esiste già online. Passa force:true per sovrascriverlo.` },
+                { status: 409 }
+            );
+        }
     }
 
     // 4. Dati reali per i tre box (mai dal payload)
@@ -442,7 +481,7 @@ export async function POST(request: NextRequest) {
 
     // 5. Composizione del file (frontmatter via gray-matter, mai YAML a mano)
     const isoDate = new Date().toISOString().slice(0, 10);
-    const frontmatter = {
+    const frontmatter: Record<string, unknown> = {
         title: payload.title,
         date: isoDate,
         description: payload.description,
@@ -459,12 +498,20 @@ export async function POST(request: NextRequest) {
             box3,
         },
     };
-    const fileContent = matter.stringify(`${payload.body_md.trim()}\n`, frontmatter);
+    // Bozza: presente sul repo (così la GitHub Action genera la copertina) ma nascosta al sito.
+    if (preview) {
+        frontmatter.draft = true;
+    }
+    const fileContent = matter.stringify(`${payload.body_md.trim()}
+`, frontmatter);
 
     // 6. Commit su GitHub
+    const commitMsg = preview
+        ? `Gazzetta: bozza giornata ${giornata} (preview copertina)`
+        : `Gazzetta: giornata ${giornata}`;
     let commitSha: string;
     try {
-        commitSha = await committaFile(owner, repo, repoPath, fileContent, `Gazzetta: giornata ${giornata}`, ghToken, shaEsistente);
+        commitSha = await committaFile(owner, repo, repoPath, fileContent, commitMsg, ghToken, shaEsistente);
     } catch (e: any) {
         return NextResponse.json(
             { ok: false, error: `Commit su GitHub fallito: ${e.message}. Riprova; se persiste controlla GAZZETTA_GH_TOKEN.` },
@@ -479,8 +526,13 @@ export async function POST(request: NextRequest) {
             slug,
             giornata,
             commit: commitSha,
+            preview,
+            pubblicato: !preview,
             liveUrl: `https://www.fantalaghee.live/gazzetta/${slug}`,
             coverUrl: `https://www.fantalaghee.live/image/gazzetta/${slug}.png`,
+            nota: preview
+                ? 'Bozza salvata come draft: non compare in elenco né è leggibile sul sito. Attendi la copertina, poi pubblica senza preview dopo OK immagine.'
+                : 'Articolo pubblicato online.',
         },
         { status: 201 }
     );

--- a/app/api/gazzetta/stato/route.ts
+++ b/app/api/gazzetta/stato/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
+import matter from 'gray-matter';
 import { getSeason } from '@/lib/seasons';
 
 export const runtime = 'nodejs';
@@ -53,7 +54,7 @@ async function leggiGiornataFoglio(origin: string, stagione: string): Promise<nu
     }
 }
 
-/** Giornata più alta già pubblicata, dai nomi file public/articoli/md/gazzetta-g{N}.md. */
+/** Giornata più alta già pubblicata ONLINE (esclude bozze draft:true). */
 function leggiGiornataPubblicata(): number {
     try {
         const mdDir = path.join(process.cwd(), 'public', 'articoli', 'md');
@@ -61,7 +62,16 @@ function leggiGiornataPubblicata(): number {
         let max = 0;
         for (const f of files) {
             const m = f.match(/^gazzetta-g(\d+)\.md$/);
-            if (m) max = Math.max(max, parseInt(m[1], 10));
+            if (!m) continue;
+            try {
+                const raw = fs.readFileSync(path.join(mdDir, f), 'utf8');
+                const { data } = matter(raw);
+                if (data?.draft === true) continue; // preview: non conta come pubblicata
+            } catch {
+                // se non leggiamo il frontmatter, per prudenza non contiamo il file
+                continue;
+            }
+            max = Math.max(max, parseInt(m[1], 10));
         }
         return max;
     } catch (e) {

--- a/docs/HERMES_PLAYBOOK.md
+++ b/docs/HERMES_PLAYBOOK.md
@@ -5,13 +5,16 @@ articolo della Gazzetta, dall'inizio alla fine. Hermes deve rileggerlo a ogni es
 
 Ruoli:
 - **Hermes**: legge lo stato, scrive l'articolo, scrive il prompt dell'illustrazione
-  in inglese (`image_prompt`), manda la bozza su Telegram, poi pubblica con una singola
-  chiamata HTTP. Hermes **non tocca GitHub, non genera immagini, non compila numeri**.
+  in inglese (`image_prompt`), manda la bozza su Telegram, fa generare la copertina in
+  **preview** (senza andare online), e solo dopo OK testo+immagine pubblica sul sito.
+  Hermes **non tocca GitHub, non genera immagini, non compila numeri**.
 - **`/api/gazzetta/stato`**: dice se una giornata è pronta da raccontare (calcolato dai
-  dati reali, non da un'attesa a occhio).
+  dati reali, non da un'attesa a occhio). Le bozze `draft:true` **non** contano come
+  pubblicate.
 - **`/api/gazzetta/publish`**: riceve la bozza, legge i dati reali di giornata, compila i
-  tre box, scrive il file `.md` e lo committa su `main` — un'unica chiamata sostituisce
-  YAML a mano e commit git.
+  tre box, scrive il file `.md` e lo committa su `main`. Con `preview:true` salva una
+  **bozza nascosta** (`draft: true`) solo per far partire la copertina; senza `preview`
+  (dopo OK immagine) fa il **go-live** vero.
 - **GitHub Action** (`.github/workflows/gazzetta-cover.yml`): genera l'illustrazione hero
   dall'`image_prompt` (catena di provider con riferimento alle copertine storiche) e
   compone la copertina finale con Puppeteer (template rosa + hero + 3 box dati).
@@ -27,12 +30,16 @@ Ruoli:
 
 ---
 
-## ⛔ Regola dei due STOP (la più importante di tutte)
+## ⛔ Flusso a due STOP (niente online prima dell'OK immagine)
 
-La procedura ha **due punti in cui devi fermarti e aspettare un click esplicito**:
+Ordine fisso:
 
-1. **Passo 3b** — conferma del **testo**, prima di pubblicare.
-2. **Passo 5** — conferma dell'**immagine**, prima di consegnare il messaggio WhatsApp.
+1. **STOP 1 — testo** (passo 3b): l'utente legge la bozza e dà il primo OK.
+2. **Preview copertina** (passo 4): Hermes salva una **bozza `draft`** (`preview:true`)
+   che **non compare sul sito** e fa generare la copertina ufficiale.
+3. **STOP 2 — immagine** (passo 5): Hermes manda la copertina e aspetta OK / Rigenera.
+4. **Go-live** (passo 6): **solo dopo ✅ Ok immagine** Hermes richiama publish **senza**
+   `preview` (articolo + copertina online) e prepara il messaggio WhatsApp.
 
 **UI obbligatoria: bottoni Telegram cliccabili** via tool `clarify` (inline keyboard
 del gateway Hermes). Non chiedere di scrivere a mano `"ok testo"` / `"ok immagine"`.
@@ -40,9 +47,8 @@ Non chiamare la Bot API a mano con `callback_data` custom: il gateway Hermes ign
 callback sconosciuti. `clarify` manda i bottoni, blocca finché l'utente clicca, toglie
 la tastiera e restituisce la scelta. Timeout clarify ≠ sì (rimanda i bottoni).
 
-In entrambi gli stop: **non pubblicare / non mandare WhatsApp** finché non arriva il
-click. Una volta pubblicato è online. **Il silenzio non è un sì**, e nemmeno un
-"bello!" generico è una conferma se non è riferito a quella domanda.
+**Il silenzio non è un sì.** Nemmeno un "bello!" generico è conferma se non è riferito
+a quella domanda. **Niente go-live e niente WhatsApp** finché non ci sono entrambi gli OK.
 
 Se l'utente ti chiede di fare tutto in autonomia, spiega che le due conferme sono
 volute e chiedi comunque.
@@ -160,9 +166,9 @@ impaginazioni dentro l'immagine, altrimenti esce un giornale dentro il giornale.
 Niente testo leggibile nell'immagine: le scritte le mette il template, e i modelli le
 disegnano storte. Se serve evocare una scritta, usa un cartello **vuoto** o un simbolo.
 
-### 3b. Conferma del TESTO (STOP OBBLIGATORIO)
+### 3b. Conferma del TESTO (STOP 1 — OBBLIGATORIO)
 
-⛔ **Stop vero: niente publish finché non arriva il click.**
+⛔ **Stop vero: niente preview e niente go-live finché non arriva il click sul testo.**
 
 1. Manda su Telegram la bozza completa (`title`, `description`, `body_md`, `image_prompt`).
 2. Subito dopo chiama il tool **`clarify`** con bottoni:
@@ -170,19 +176,23 @@ disegnano storte. Se serve evocare una scritta, usa un cartello **vuoto** o un s
 ```
 clarify(
   question="Confermi il TESTO della Gazzetta?",
-  choices=["✅ Pubblica", "✏️ Modifica", "🔄 Rifai"]
+  choices=["✅ Ok testo", "✏️ Modifica", "🔄 Rifai"]
 )
 ```
 
 3. Interpreta la scelta:
-   - **✅ Pubblica** (o ok/vai/👍 esplicito) → passo 4 con `"conferma": true`
+   - **✅ Ok testo** (o ok/vai/👍 esplicito) → passo 4 (**preview**, non go-live)
    - **✏️ Modifica** → chiedi cosa cambiare, riscrivi, di nuovo STOP 1
    - **🔄 Rifai** → rigenera da capo, di nuovo STOP 1
 
-**Il silenzio non è un sì.** Timeout clarify ≠ sì. Senza click (o ok testuale
-equivalente via Other) non si pubblica.
+**Il silenzio non è un sì.** Timeout clarify ≠ sì.
 
-### 4. Pubblica
+### 4. Preview copertina (SENZA andare online)
+
+Dopo ✅ Ok testo chiama publish con **`preview: true`** e **`conferma: true`**.
+Il server scrive l'articolo come **bozza** (`draft: true` nel frontmatter): la GitHub
+Action genera la copertina, ma l'articolo **non compare** in elenco Gazzetta e l'URL
+diretto risponde 404 finché non fai il go-live.
 
 ```
 POST https://www.fantalaghee.live/api/gazzetta/publish
@@ -198,34 +208,36 @@ Content-Type: application/json
     "sottotitolo": "Sommario della giornata, max 180 caratteri",
     "image_prompt": "Detailed English prompt for the satirical hero illustration"
   },
+  "preview": true,
   "conferma": true
 }
 ```
 
-`"conferma": true` va messo **solo dopo ✅ Pubblica al passo 3b**. Senza,
-il server risponde `409` e non pubblica: è la rete di sicurezza contro la pubblicazione
-non autorizzata. Non aggiungerlo mai di tua iniziativa per "sbloccare" la chiamata.
+`"conferma": true` va messo **solo dopo ✅ Ok testo al passo 3b**. Senza, il server
+risponde `409`. Non aggiungerlo mai di tua iniziativa.
 
 Non includere `box1`/`box2`/`box3`, `giornata` o `stagione`: il server li ricava da solo
 (li puoi passare solo se stai deliberatamente forzando una giornata specifica, caso raro).
+In force esplicito: aggiungi anche `giornata`, `stagione`, `force: true` insieme a
+`preview: true`.
 
 Risposte:
-- **`201`** → pubblicato. Contiene `slug`, `commit`, `liveUrl`, `coverUrl`. Vai al passo 5.
-- **`409` con `richiedeConferma: true`** → hai saltato la conferma dell'utente. Torna al
-  passo 3b, mostra la bozza e aspetta il click sui bottoni.
-- **`400`** → `dettagli` elenca ogni campo da correggere. Correggi e ripeti la chiamata.
-- **`409`** → l'articolo esiste già o la giornata non è pronta. Riporta `error` all'utente
-  e fermati (non ripetere con `force` senza che l'utente lo chieda esplicitamente).
-- **`401`/`500`** → problema di configurazione lato server. Riporta l'errore e fermati.
+- **`201` con `preview: true`** → bozza salvata. Contiene `slug`, `commit`, `coverUrl`.
+  **Non** è online (`pubblicato: false`). Vai al passo 5.
+- **`409` con `richiedeConferma: true`** → hai saltato STOP 1. Torna al 3b.
+- **`400`** → `dettagli` elenca ogni campo da correggere. Correggi e ripeti.
+- **`409`** → articolo **live** già esistente (non bozza). Riporta e fermati, o `force`
+  solo se l'utente lo chiede esplicitamente. Una bozza draft esistente si può aggiornare
+  senza force.
+- **`401`/`500`** → config lato server. Riporta e fermati.
 
-### 5. Conferma dell'IMMAGINE (STOP OBBLIGATORIO)
+### 5. Conferma dell'IMMAGINE (STOP 2 — OBBLIGATORIO)
 
-Attendi ~90 secondi (tempo di run della GitHub Action che genera la copertina), poi
-controlla che `coverUrl` risponda 200 con body PNG valido (**max 4–5 tentativi, ~60s
-di distanza**). Se dopo i tentativi non risponde ancora, avvisa l'utente che la Action
-potrebbe essere fallita (tab Actions di GitHub) e fermati.
+Attendi ~90–150 secondi (GitHub Action), poi controlla che `coverUrl` risponda 200 con
+body PNG valido (**max 4–5 tentativi, ~60s di distanza**). Se non arriva, avvisa che la
+Action potrebbe essere fallita e fermati.
 
-⛔ **Secondo stop vero.** Quando la copertina è pronta:
+⛔ **Secondo stop vero — ancora niente go-live.** Quando la copertina è pronta:
 
 1. **Mandala su Telegram come immagine** (`MEDIA:/path` o allegato nativo).
 2. Subito **`clarify`** con bottoni:
@@ -238,7 +250,7 @@ clarify(
 ```
 
 3. Interpreta:
-   - **✅ Ok immagine** → passo 6 (WhatsApp)
+   - **✅ Ok immagine** → passo 6 (go-live + WhatsApp)
    - **🔄 Rigenera** → chiama:
 
 ```
@@ -249,19 +261,37 @@ Content-Type: application/json
 { "giornata": 7 }
 ```
 
-Il server fa ripartire la generazione con un **seed diverso** (non serve passare il seed:
-lo sceglie lui e te lo torna). Poi ri-attendi ~90 secondi, ricontrolla `coverUrl` e
-rimanda la nuova copertina + di nuovo i bottoni. Ripeti finché l'utente approva.
-- `403` → il token GitHub non può avviare le Action: riporta il messaggio (l'utente può
-  rigenerare a mano dalla tab Actions) e prosegui col passo 6 se l'immagine attuale basta.
+Poi ri-attendi la PNG, rimanda copertina + di nuovo i bottoni.
+- `403` → token GitHub non avvia Action: riporta; se l'immagine attuale basta e l'utente
+  la approva, prosegui al passo 6.
 
-**NON mandare il messaggio WhatsApp (passo 6) finché l'utente non ha approvato l'immagine
-col bottone (o ok testuale equivalente).** L'articolo è già online, ma non va condiviso
-finché testo e immagine non sono ok.
+Se l'utente chiede di **cancellare / lasciare perdere** a questo punto: `DELETE` a due
+passi (come sotto) sulla bozza — niente go-live, niente WhatsApp.
 
-### 6. Consegna (solo dopo l'OK su testo E immagine)
+### 6. Go-live + consegna WhatsApp (solo dopo ✅ Ok immagine)
 
-Manda all'utente il messaggio pronto da incollare su WhatsApp:
+**Solo ora** pubblica online **senza** `preview` (stesso payload testo/cover, con
+`conferma: true`). Se esiste già la bozza draft, il server la promuove a live senza
+richiedere `force`. La copertina già generata resta (la Action non la rigenera se il PNG
+c'è già).
+
+```
+POST https://www.fantalaghee.live/api/gazzetta/publish
+Authorization: stesso Bearer del publish
+Content-Type: application/json
+
+{
+  "title": "...",
+  "description": "...",
+  "body_md": "...",
+  "cover": { "titolo_principale": "...", "sottotitolo": "...", "image_prompt": "..." },
+  "conferma": true
+}
+```
+
+Risposta attesa: `201` con `pubblicato: true`, `liveUrl`, `coverUrl`.
+
+Poi manda all'utente il messaggio pronto da incollare su WhatsApp:
 
 ```
 📰 *La Gazzetta del Laghèe* — Giornata {N}


### PR DESCRIPTION
## Summary
- publish preview:true → draft nascosto + copertina
- seconda publish senza preview → go-live
- articles/stato ignorano draft
- playbook: Ok testo → preview → Ok immagine → go-live + WhatsApp

## Test
Force G38/2526 col nuovo flusso